### PR TITLE
fix: stop log monitor feedback loop causing 2.4M-line log spam

### DIFF
--- a/simplenote_mcp/server/log_monitor.py
+++ b/simplenote_mcp/server/log_monitor.py
@@ -212,7 +212,8 @@ class LogPatternMonitor:
                 time_window_minutes=5,
                 field_filters={"level": "ERROR"},
             ),
-            # Security-related warnings
+            # Security-related warnings (WARNING+ only to avoid matching routine
+            # INFO messages like "Security alerter initialized")
             SuspiciousPattern(
                 name="security_warnings",
                 pattern=r"(security|suspicious|malicious|attack|breach|unauthorized)",
@@ -220,6 +221,7 @@ class LogPatternMonitor:
                 description="Security-related warnings detected",
                 threshold=3,
                 time_window_minutes=10,
+                field_filters={"level": "WARNING"},
             ),
             # Unusual resource access patterns
             SuspiciousPattern(
@@ -286,21 +288,18 @@ class LogPatternMonitor:
         Args:
             log_entry: Log entry data to analyze
         """
+        # Skip own-logger entries to prevent a feedback loop: the debug message
+        # "Pattern matched: security_warnings" contains "security", which
+        # matches the security_warnings pattern, which logs again, and so on.
+        if log_entry.get("logger", "").startswith("simplenote_mcp.log_monitor"):
+            return
+
         self.stats["logs_processed"] += 1
 
         # Check each pattern
         for pattern in self.patterns:
             if pattern.check_match(log_entry):
                 self.stats["patterns_matched"] += 1
-
-                logger.debug(
-                    f"Pattern matched: {pattern.name}",
-                    extra={
-                        "pattern_name": pattern.name,
-                        "log_message": log_entry.get("message", ""),
-                        "match_count": len(pattern.matches),
-                    },
-                )
 
                 # Check if we should trigger an alert
                 if pattern.should_trigger_alert():


### PR DESCRIPTION
## Summary

- **Root cause**: `process_log_entry` emitted `DEBUG "Pattern matched: security_warnings"` on every match. That message contains the word "security", which matched the `security_warnings` pattern, which logged again — a self-reinforcing loop that wrote ~2.4 million lines to the log file per session.
- **Fix 1**: Skip log entries from `simplenote_mcp.log_monitor` itself in `process_log_entry` — the monitor no longer processes its own output.
- **Fix 2**: Remove the per-match `logger.debug` entirely — match counts are already tracked in `self.stats["patterns_matched"]`.
- **Fix 3**: Add `field_filters={"level": "WARNING"}` to the `security_warnings` pattern so routine INFO startup messages ("Security alerter initialized", "Started log pattern monitoring for security alerts") no longer trigger a false-positive `SECURITY ALERT` at startup.

## Test plan

- [x] All 1184 tests pass (`SIMPLENOTE_OFFLINE_MODE=true pytest tests/ --no-cov`)
- [x] All pre-commit hooks pass (bandit, ruff, mypy)
- [x] Log monitor unit tests (25 passing, 1 skipped) confirm pattern matching and alert logic still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent the log monitor from re-processing its own output and reduce noisy security-related logging.

Bug Fixes:
- Stop log monitor feedback loops by ignoring log entries emitted by the log monitor logger itself, preventing recursive pattern matches and log spam.

Enhancements:
- Restrict the security_warnings pattern to WARNING level entries to avoid triggering on routine informational security messages.
- Remove per-match debug logging for pattern matches to reduce unnecessary log noise while retaining match statistics.