### PR TITLE
feat: MCP annotations, write-mode gate, write budget, list_notes, shrink guard, no-op revert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ SIMPLENOTE_PASSWORD=your_password
 # One of: DEBUG, INFO, WARNING, ERROR  (default: INFO)
 # LOG_LEVEL=INFO
 
+# ── Write mode ────────────────────────────────────────────────────────────────
+# Expose create/update/delete tools. Off by default — set to true to enable.
+# SIMPLENOTE_WRITE_MODE=false
+
 # ── Offline / testing ─────────────────────────────────────────────────────────
 # Skip Simplenote API calls — used by the test suite and local dev without creds
 # SIMPLENOTE_OFFLINE_MODE=false

--- a/simplenote_mcp/server/config.py
+++ b/simplenote_mcp/server/config.py
@@ -143,6 +143,22 @@ class Config:
             "yes",
         )
 
+        # Write-mode configuration — off by default for safety.
+        # Set SIMPLENOTE_WRITE_MODE=true to expose tools that create, modify,
+        # or delete notes. Read-only tools are always available.
+        self.write_mode: bool = os.environ.get(
+            "SIMPLENOTE_WRITE_MODE", "false"
+        ).lower() in ("true", "1", "t", "yes")
+
+        # Write-budget configuration — caps write operations per rolling window
+        # to prevent LLM runaway loops. Applied per server session.
+        self.write_budget_max: int = int(
+            os.environ.get("SIMPLENOTE_WRITE_BUDGET", "20")
+        )
+        self.write_budget_window_seconds: int = int(
+            os.environ.get("SIMPLENOTE_WRITE_BUDGET_WINDOW", "60")
+        )
+
     @property
     def has_credentials(self) -> bool:
         """Check if Simplenote credentials are configured."""

--- a/simplenote_mcp/server/server.py
+++ b/simplenote_mcp/server/server.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import threading
 import time
+from collections import deque
 from typing import Any, cast
 
 # MCP imports
@@ -94,6 +95,66 @@ FAILED_GET_NOTE = "Failed to find note with ID {note_id}"
 FAILED_UPDATE_TAGS = "Failed to update note tags"
 FAILED_TRASH_NOTE = "Failed to move note to trash"
 FAILED_RETRIEVE_NOTES = "Failed to retrieve notes for search"
+
+# Tools that mutate Simplenote data. Only exposed when write_mode is enabled,
+# and counted against the per-session write budget.
+WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "create_note",
+        "update_note",
+        "delete_note",
+        "add_tags",
+        "remove_tags",
+        "replace_tags",
+        "add_text",
+        "restore_version",
+        "replace_section",
+        "append_to_daily_note",
+        "get_or_create_note",
+        "rename_tag",
+        "bulk_tag",
+        "restore_note",
+        "publish_note",
+        "unpublish_note",
+        "permanent_delete_note",
+        "empty_trash",
+        "find_and_merge_duplicates",
+    }
+)
+
+# Per-session rolling write-budget tracker (not reset across reconnects —
+# intentional: keeps the guard effective during a single server process).
+_write_timestamps: deque[float] = deque()
+_write_budget_lock = threading.Lock()
+
+
+def _check_write_budget() -> None:
+    """Raise ValidationError if the session write budget is exhausted.
+
+    Uses a rolling window defined by config write_budget_max /
+    write_budget_window_seconds.  Called immediately before each write tool
+    dispatch so idempotency short-circuits (no-ops) don't consume budget.
+    """
+    config = get_config()
+    now = time.monotonic()
+    window_start = now - config.write_budget_window_seconds
+    with _write_budget_lock:
+        while _write_timestamps and _write_timestamps[0] < window_start:
+            _write_timestamps.popleft()
+        if len(_write_timestamps) >= config.write_budget_max:
+            raise ValidationError(
+                f"Write budget exhausted: {config.write_budget_max} writes in "
+                f"{config.write_budget_window_seconds}s. "
+                "Confirm with the user that this bulk operation should continue before retrying.",
+                subcategory="rate_limited",
+            )
+
+
+def _record_write() -> None:
+    """Record a successful write operation against the session budget."""
+    with _write_budget_lock:
+        _write_timestamps.append(time.monotonic())
+
 
 # Create a server instance
 try:
@@ -677,72 +738,69 @@ async def handle_list_tools() -> list[types.Tool]:
         List of available tools
 
     """
+    # Annotation presets
+    _READ = types.ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+    _ADD = types.ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    )
+    _ADD_IDEM = types.ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+    _WRITE = types.ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=True,
+    )
+    _WRITE_IDEM = types.ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+
     try:
+        config = get_config()
         logger.info("Listing available tools")
-        tools = [
+
+        read_tools = [
             types.Tool(
-                name="create_note",
+                name="list_notes",
                 description=(
-                    "Create a new note in Simplenote. "
-                    "Use get_or_create_note (once available) if you need to avoid duplicate notes."
+                    "List recent notes, optionally filtered by tag. "
+                    "Use search_notes for full-text or boolean queries. "
+                    "Use list_tags first to discover available tag names."
                 ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "content": {
+                        "tag": {
                             "type": "string",
-                            "description": "The content of the note",
+                            "description": "Filter by tag name (exact match)",
                         },
-                        "tags": {
-                            "type": "string",
-                            "description": "Tags for the note (comma-separated)",
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum number of notes to return (default: 20, max: 100)",
                         },
-                    },
-                    "required": ["content"],
-                },
-            ),
-            types.Tool(
-                name="update_note",
-                description=(
-                    "Replaces the full note content in Simplenote. "
-                    "Use add_text instead when you only want to append or prepend content "
-                    "without overwriting the full note."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "note_id": {
-                            "type": "string",
-                            "description": "The ID of the note to update",
-                        },
-                        "content": {
-                            "type": "string",
-                            "description": "The new content of the note",
-                        },
-                        "tags": {
-                            "type": "string",
-                            "description": "Tags for the note (comma-separated)",
+                        "include_deleted": {
+                            "type": "boolean",
+                            "description": "Include trashed notes (default: false)",
                         },
                     },
-                    "required": ["note_id", "content"],
+                    "required": [],
                 },
-            ),
-            types.Tool(
-                name="delete_note",
-                description=(
-                    "Soft-deletes a note from Simplenote (moves to Trash). "
-                    "Use restore_note to undo. The note is not permanently deleted."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "note_id": {
-                            "type": "string",
-                            "description": "The ID of the note to delete",
-                        }
-                    },
-                    "required": ["note_id"],
-                },
+                annotations=_READ,
             ),
             types.Tool(
                 name="search_notes",
@@ -813,6 +871,7 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["query"],
                 },
+                annotations=_READ,
             ),
             types.Tool(
                 name="get_note",
@@ -830,69 +889,59 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["note_id"],
                 },
+                annotations=_READ,
             ),
             types.Tool(
-                name="add_tags",
+                name="list_tags",
                 description=(
-                    "Add tags to an existing note without replacing existing ones. "
-                    "Use replace_tags to set the complete tag list from scratch."
+                    "List all tags used across notes with note counts. "
+                    "Use this before creating or searching by tags to discover existing tags "
+                    "and avoid fragmentation."
                 ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "sort_by": {
+                            "type": "string",
+                            "enum": ["alpha", "count"],
+                            "description": "Sort order: 'alpha' (alphabetical, default) or 'count' (by note count descending)",
+                        },
+                    },
+                    "required": [],
+                },
+                annotations=_READ,
+            ),
+            types.Tool(
+                name="get_note_versions",
+                description="Retrieve the version history of a note (up to 10 most recent versions).",
                 inputSchema={
                     "type": "object",
                     "properties": {
                         "note_id": {
                             "type": "string",
-                            "description": "The ID of the note to modify",
-                        },
-                        "tags": {
-                            "type": "string",
-                            "description": "Tags to add (comma-separated)",
+                            "description": "The ID of the note",
                         },
                     },
-                    "required": ["note_id", "tags"],
+                    "required": ["note_id"],
                 },
+                annotations=_READ,
             ),
             types.Tool(
-                name="remove_tags",
+                name="find_untagged_notes",
                 description=(
-                    "Remove specific tags from an existing note. "
-                    "Use replace_tags to set an entirely new tag list."
+                    "List notes that have no tags. "
+                    "Useful for tag housekeeping — find notes that need to be organized."
                 ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "note_id": {
-                            "type": "string",
-                            "description": "The ID of the note to modify",
-                        },
-                        "tags": {
-                            "type": "string",
-                            "description": "Tags to remove (comma-separated)",
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum number of notes to return (default: 50)",
                         },
                     },
-                    "required": ["note_id", "tags"],
                 },
-            ),
-            types.Tool(
-                name="replace_tags",
-                description=(
-                    "Replace ALL tags on an existing note. "
-                    "Use add_tags or remove_tags for partial changes."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "note_id": {
-                            "type": "string",
-                            "description": "The ID of the note to modify",
-                        },
-                        "tags": {
-                            "type": "string",
-                            "description": "New tags (comma-separated)",
-                        },
-                    },
-                    "required": ["note_id", "tags"],
-                },
+                annotations=_READ,
             ),
             types.Tool(
                 name="export_notes",
@@ -916,28 +965,158 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["note_ids"],
                 },
+                annotations=_READ,
             ),
             types.Tool(
-                name="find_and_merge_duplicates",
-                description="Find duplicate or near-duplicate notes and optionally merge them",
+                name="get_server_info",
+                description=(
+                    "Return version, author, and debug information about this MCP server. "
+                    "Use this to confirm which version is running, check whether the cache "
+                    "is initialized, and see runtime settings (log level, sync interval, "
+                    "offline mode). No parameters required."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {},
+                },
+                annotations=_READ,
+            ),
+        ]
+
+        write_tools = [
+            types.Tool(
+                name="create_note",
+                description=(
+                    "Create a new note in Simplenote. "
+                    "Use get_or_create_note if you need to avoid duplicate notes."
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "threshold": {
-                            "type": "number",
-                            "description": "Similarity threshold from 0.0 to 1.0 (default: 0.8). Higher values require more similarity.",
-                        },
-                        "dry_run": {
-                            "type": "boolean",
-                            "description": "If true (default), only report duplicates without merging. Set to false to actually merge.",
-                        },
-                        "tag_filter": {
+                        "content": {
                             "type": "string",
-                            "description": "Only check notes with this tag (optional, helps narrow scope)",
+                            "description": "The content of the note",
+                        },
+                        "tags": {
+                            "type": "string",
+                            "description": "Tags for the note (comma-separated)",
                         },
                     },
-                    "required": [],
+                    "required": ["content"],
                 },
+                annotations=_ADD,
+            ),
+            types.Tool(
+                name="update_note",
+                description=(
+                    "Replaces the full note content in Simplenote. "
+                    "IMPORTANT: content replaces the entire note — call get_note first when "
+                    "changing only part of it. "
+                    "Use add_text to append or prepend without overwriting."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "note_id": {
+                            "type": "string",
+                            "description": "The ID of the note to update",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "The new content of the note",
+                        },
+                        "tags": {
+                            "type": "string",
+                            "description": "Tags for the note (comma-separated)",
+                        },
+                    },
+                    "required": ["note_id", "content"],
+                },
+                annotations=_WRITE,
+            ),
+            types.Tool(
+                name="delete_note",
+                description=(
+                    "Soft-deletes a note from Simplenote (moves to Trash). "
+                    "Use restore_note to undo. The note is not permanently deleted."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "note_id": {
+                            "type": "string",
+                            "description": "The ID of the note to delete",
+                        }
+                    },
+                    "required": ["note_id"],
+                },
+                annotations=_WRITE_IDEM,
+            ),
+            types.Tool(
+                name="add_tags",
+                description=(
+                    "Add tags to an existing note without replacing existing ones. "
+                    "Use replace_tags to set the complete tag list from scratch."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "note_id": {
+                            "type": "string",
+                            "description": "The ID of the note to modify",
+                        },
+                        "tags": {
+                            "type": "string",
+                            "description": "Tags to add (comma-separated)",
+                        },
+                    },
+                    "required": ["note_id", "tags"],
+                },
+                annotations=_ADD_IDEM,
+            ),
+            types.Tool(
+                name="remove_tags",
+                description=(
+                    "Remove specific tags from an existing note. "
+                    "Use replace_tags to set an entirely new tag list."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "note_id": {
+                            "type": "string",
+                            "description": "The ID of the note to modify",
+                        },
+                        "tags": {
+                            "type": "string",
+                            "description": "Tags to remove (comma-separated)",
+                        },
+                    },
+                    "required": ["note_id", "tags"],
+                },
+                annotations=_WRITE_IDEM,
+            ),
+            types.Tool(
+                name="replace_tags",
+                description=(
+                    "Replace ALL tags on an existing note. "
+                    "Use add_tags or remove_tags for partial changes."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "note_id": {
+                            "type": "string",
+                            "description": "The ID of the note to modify",
+                        },
+                        "tags": {
+                            "type": "string",
+                            "description": "New tags (comma-separated)",
+                        },
+                    },
+                    "required": ["note_id", "tags"],
+                },
+                annotations=_WRITE,
             ),
             types.Tool(
                 name="add_text",
@@ -965,57 +1144,7 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["note_id", "text"],
                 },
-            ),
-            types.Tool(
-                name="list_tags",
-                description=(
-                    "List all tags used across notes with note counts. "
-                    "Use this before creating or searching by tags to discover existing tags "
-                    "and avoid fragmentation."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "sort_by": {
-                            "type": "string",
-                            "enum": ["alpha", "count"],
-                            "description": "Sort order: 'alpha' (alphabetical, default) or 'count' (by note count descending)",
-                        },
-                    },
-                    "required": [],
-                },
-            ),
-            types.Tool(
-                name="get_note_versions",
-                description="Retrieve the version history of a note (up to 10 most recent versions).",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "note_id": {
-                            "type": "string",
-                            "description": "The ID of the note",
-                        },
-                    },
-                    "required": ["note_id"],
-                },
-            ),
-            types.Tool(
-                name="restore_version",
-                description="Restore a note to a specific earlier version. Use get_note_versions first to see available versions.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "note_id": {
-                            "type": "string",
-                            "description": "The ID of the note to restore",
-                        },
-                        "version": {
-                            "type": "integer",
-                            "description": "The version number to restore to",
-                        },
-                    },
-                    "required": ["note_id", "version"],
-                },
+                annotations=_ADD,
             ),
             types.Tool(
                 name="replace_section",
@@ -1038,6 +1167,30 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["note_id", "header", "new_content"],
                 },
+                annotations=_WRITE,
+            ),
+            types.Tool(
+                name="restore_version",
+                description=(
+                    "Restore a note to a specific earlier version. "
+                    "Use get_note_versions first to see available versions. "
+                    "No-op (returns no_op=true) if the target version is identical to current."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "note_id": {
+                            "type": "string",
+                            "description": "The ID of the note to restore",
+                        },
+                        "version": {
+                            "type": "integer",
+                            "description": "The version number to restore to",
+                        },
+                    },
+                    "required": ["note_id", "version"],
+                },
+                annotations=_WRITE_IDEM,
             ),
             types.Tool(
                 name="append_to_daily_note",
@@ -1052,6 +1205,7 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["text"],
                 },
+                annotations=_ADD,
             ),
             types.Tool(
                 name="get_or_create_note",
@@ -1078,6 +1232,7 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["title"],
                 },
+                annotations=_ADD,
             ),
             types.Tool(
                 name="rename_tag",
@@ -1100,6 +1255,7 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["old_tag", "new_tag"],
                 },
+                annotations=_WRITE,
             ),
             types.Tool(
                 name="bulk_tag",
@@ -1128,6 +1284,7 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["note_ids", "action", "tags"],
                 },
+                annotations=_WRITE,
             ),
             types.Tool(
                 name="restore_note",
@@ -1145,44 +1302,14 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["note_id"],
                 },
-            ),
-            types.Tool(
-                name="find_untagged_notes",
-                description=(
-                    "List notes that have no tags. "
-                    "Useful for tag housekeeping — find notes that need to be organized."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "limit": {
-                            "type": "integer",
-                            "description": "Maximum number of notes to return (default: 50)",
-                        },
-                    },
-                },
-            ),
-            types.Tool(
-                name="get_server_info",
-                description=(
-                    "Return version, author, and debug information about this MCP server. "
-                    "Use this to confirm which version is running, check whether the cache "
-                    "is initialized, and see runtime settings (log level, sync interval, "
-                    "offline mode). No parameters required."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {},
-                },
+                annotations=_ADD_IDEM,
             ),
             types.Tool(
                 name="publish_note",
                 description=(
                     "Publish a note to a public URL accessible without login. "
                     "Sets the 'published' system tag and returns the public_url. "
-                    "Use this to share a note publicly. "
-                    "Use unpublish_note to reverse. "
-                    "Note: the public URL is generated by Simperium after the first publish."
+                    "Use unpublish_note to reverse."
                 ),
                 inputSchema={
                     "type": "object",
@@ -1194,14 +1321,13 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["note_id"],
                 },
+                annotations=_ADD_IDEM,
             ),
             types.Tool(
                 name="unpublish_note",
                 description=(
                     "Remove a note from public access by clearing its 'published' system tag. "
-                    "Reverses publish_note. "
-                    "Use this when a previously-shared note should no longer be publicly accessible. "
-                    "No-op if the note is already unpublished."
+                    "Reverses publish_note. No-op if the note is already unpublished."
                 ),
                 inputSchema={
                     "type": "object",
@@ -1213,6 +1339,30 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["note_id"],
                 },
+                annotations=_WRITE_IDEM,
+            ),
+            types.Tool(
+                name="find_and_merge_duplicates",
+                description="Find duplicate or near-duplicate notes and optionally merge them",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "threshold": {
+                            "type": "number",
+                            "description": "Similarity threshold from 0.0 to 1.0 (default: 0.8). Higher values require more similarity.",
+                        },
+                        "dry_run": {
+                            "type": "boolean",
+                            "description": "If true (default), only report duplicates without merging. Set to false to actually merge.",
+                        },
+                        "tag_filter": {
+                            "type": "string",
+                            "description": "Only check notes with this tag (optional, helps narrow scope)",
+                        },
+                    },
+                    "required": [],
+                },
+                annotations=_WRITE,
             ),
             types.Tool(
                 name="permanent_delete_note",
@@ -1240,6 +1390,7 @@ async def handle_list_tools() -> list[types.Tool]:
                     },
                     "required": ["note_id", "confirm"],
                 },
+                annotations=_WRITE_IDEM,
             ),
             types.Tool(
                 name="empty_trash",
@@ -1268,31 +1419,21 @@ async def handle_list_tools() -> list[types.Tool]:
                         },
                     },
                 },
+                annotations=_WRITE_IDEM,
             ),
         ]
+
+        tools = read_tools + (write_tools if config.write_mode else [])
         logger.info(
-            f"Returning {len(tools)} tools: {', '.join([t.name for t in tools])}"
+            f"Returning {len(tools)} tools "
+            f"(write_mode={'on' if config.write_mode else 'off'}): "
+            f"{', '.join(t.name for t in tools)}"
         )
         return tools
 
     except Exception as e:
         logger.error(f"Error listing tools: {str(e)}", exc_info=True)
-        # Return at least the core tools to prevent errors
         return [
-            types.Tool(
-                name="create_note",
-                description="Create a new note in Simplenote",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "content": {
-                            "type": "string",
-                            "description": "The content of the note",
-                        }
-                    },
-                    "required": ["content"],
-                },
-            ),
             types.Tool(
                 name="search_notes",
                 description=(
@@ -1304,25 +1445,12 @@ async def handle_list_tools() -> list[types.Tool]:
                     "properties": {
                         "query": {
                             "type": "string",
-                            "description": "The search query (supports boolean operators AND, OR, NOT; phrase matching with quotes; tag filters like tag:work; date filters like from:2023-01-01 to:2023-12-31)",
-                        },
-                        "tags": {
-                            "type": "string",
-                            "description": "Tags to filter by (comma-separated list of tags that must all be present). Use 'untagged' to find notes without tags.",
-                        },
-                        "sort_by": {
-                            "type": "string",
-                            "enum": ["relevance", "modifydate", "createdate"],
-                            "description": "Sort results by field. Default: 'relevance'. Use 'modifydate' to get the most recently updated notes first.",
-                        },
-                        "sort_direction": {
-                            "type": "string",
-                            "enum": ["asc", "desc"],
-                            "description": "Sort direction: 'desc' (newest first, default) or 'asc' (oldest first).",
+                            "description": "The search query",
                         },
                     },
                     "required": ["query"],
                 },
+                annotations=types.ToolAnnotations(readOnlyHint=True),
             ),
         ]
 
@@ -1370,6 +1498,20 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
         if not note_cache.is_initialized:
             asyncio.create_task(initialize_cache())
 
+        # Enforce write-mode gate and write budget before dispatch.
+        if name in WRITE_TOOLS:
+            config = get_config()
+            if not config.write_mode:
+                error = ValidationError(
+                    f"Tool '{name}' requires write mode. "
+                    "Set SIMPLENOTE_WRITE_MODE=true to enable write operations.",
+                    subcategory="write_mode_disabled",
+                )
+                return [
+                    types.TextContent(type="text", text=json.dumps(error.to_dict()))
+                ]
+            _check_write_budget()
+
         # Get handler from registry
         registry = ToolHandlerRegistry()
         handler = registry.get_handler(name, sn, note_cache)
@@ -1380,8 +1522,11 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
             error = ValidationError(error_msg)
             return [types.TextContent(type="text", text=json.dumps(error.to_dict()))]
 
-        # Execute the tool handler
-        return await handler.handle(arguments)
+        # Execute the tool handler and record the write if it succeeded.
+        result = await handler.handle(arguments)
+        if name in WRITE_TOOLS:
+            _record_write()
+        return result
 
     except Exception as e:
         if isinstance(e, ServerError):

--- a/simplenote_mcp/server/tool_handlers.py
+++ b/simplenote_mcp/server/tool_handlers.py
@@ -273,6 +273,27 @@ class UpdateNoteHandler(ToolHandlerBase):
         try:
             existing_note = self._get_note_from_cache_or_api(note_id)
 
+            # Guard against catastrophic content replacement: refuse when the
+            # new content is drastically smaller than the existing note (likely
+            # an LLM error rather than a deliberate edit).
+            _SHRINK_MIN_CHARS = 200
+            _SHRINK_RATIO = 0.2
+            existing_content = existing_note.get("content", "") or ""
+            if (
+                len(existing_content) >= _SHRINK_MIN_CHARS
+                and len(content) < len(existing_content) * _SHRINK_RATIO
+            ):
+                from .errors import ValidationError as _VE
+
+                raise _VE(
+                    f"Refusing to replace a {len(existing_content)}-character note "
+                    f"with {len(content)} characters "
+                    f"({len(content) / max(len(existing_content), 1):.0%} of original). "
+                    "Call get_note first, make targeted edits, and pass the full merged "
+                    "content. Use add_text or replace_section for partial updates.",
+                    subcategory="suspicious_shrink",
+                )
+
             # Update the note content
             safe_set(existing_note, "content", content)
 
@@ -1565,6 +1586,29 @@ class RestoreVersionHandler(ToolHandlerBase):
                     resource_id=note_id,
                 )
 
+            # No-op detection: use cache only (avoids an extra API round-trip).
+            # If the cache has the current content and it matches the target
+            # version, skip the write entirely.
+            if self.note_cache is not None and self.note_cache.is_initialized:
+                cached = self.note_cache._notes.get(note_id)
+                if cached is not None and versioned_note.get("content") == cached.get(
+                    "content"
+                ):
+                    return [
+                        types.TextContent(
+                            type="text",
+                            text=json.dumps(
+                                {
+                                    "success": True,
+                                    "no_op": True,
+                                    "note_id": note_id,
+                                    "restored_version": version,
+                                    "message": "Target version is identical to current content — no write performed.",
+                                }
+                            ),
+                        )
+                    ]
+
             # Strip the version field so the API treats this as a new update
             restore_note = {k: v for k, v in versioned_note.items() if k != "version"}
 
@@ -2556,6 +2600,71 @@ class EmptyTrashHandler(ToolHandlerBase):
         return [n for n in notes if n.get("deleted")]
 
 
+class ListNotesHandler(ToolHandlerBase):
+    """Handler for list_notes tool — browse recent notes, optionally by tag."""
+
+    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+        """Handle list_notes tool call."""
+        tag: str | None = arguments.get("tag")
+        limit = min(int(arguments.get("limit", 20)), 100)
+        include_deleted: bool = bool(arguments.get("include_deleted", False))
+
+        try:
+            if self.note_cache is not None and self.note_cache.is_initialized:
+                notes = list(self.note_cache._notes.values())
+            else:
+                all_notes, status = self.sn.get_note_list()
+                if status != 0:
+                    raise NetworkError("Failed to retrieve note list")
+                notes = all_notes if isinstance(all_notes, list) else []
+
+            if not include_deleted:
+                notes = [n for n in notes if not n.get("deleted")]
+            if tag:
+                notes = [
+                    n
+                    for n in notes
+                    if tag.lower() in [t.lower() for t in (n.get("tags") or [])]
+                ]
+
+            # Sort: pinned first, then by modification date descending.
+            notes.sort(
+                key=lambda n: (
+                    not bool(
+                        n.get("systemTags") and "pinned" in n.get("systemTags", [])
+                    ),
+                    -(float(n.get("modifydate", 0)) if n.get("modifydate") else 0),
+                )
+            )
+            notes = notes[:limit]
+
+            results = []
+            for note in notes:
+                content = note.get("content", "") or ""
+                first_line = content.split("\n")[0].strip()[:60] if content else ""
+                results.append(
+                    {
+                        "id": note.get("key", ""),
+                        "title": first_line,
+                        "tags": note.get("tags", []),
+                        "modified": note.get("modifydate", ""),
+                        "deleted": bool(note.get("deleted")),
+                    }
+                )
+
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {"notes": results, "count": len(results), "limit": limit}
+                    ),
+                )
+            ]
+
+        except Exception as e:
+            return self._format_error_response(e, "listing notes")
+
+
 class ToolHandlerRegistry:
     """Registry for tool handlers."""
 
@@ -2566,6 +2675,7 @@ class ToolHandlerRegistry:
             "update_note": UpdateNoteHandler,
             "delete_note": DeleteNoteHandler,
             "get_note": GetNoteHandler,
+            "list_notes": ListNotesHandler,
             "search_notes": SearchNotesHandler,
             "add_tags": AddTagsHandler,
             "remove_tags": RemoveTagsHandler,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,20 @@ import pytest
 import pytest_asyncio
 
 
+@pytest.fixture(autouse=True)
+def reset_write_budget():
+    """Clear the per-session write-budget deque before every test.
+
+    The deque is module-level and would otherwise accumulate writes across
+    the whole test run, exhausting the budget mid-suite.
+    """
+    import simplenote_mcp.server.server as _srv
+
+    _srv._write_timestamps.clear()
+    yield
+    _srv._write_timestamps.clear()
+
+
 @pytest.fixture
 def mock_simplenote_client():
     """Create a mock Simplenote client for testing."""

--- a/tests/test_end_to_end_scenarios.py
+++ b/tests/test_end_to_end_scenarios.py
@@ -52,6 +52,9 @@ async def end_to_end_setup():
         mock_config.max_resource_limit = 1000
         mock_config.cache_initialization_timeout = 30  # Proper timeout value
         mock_config.sync_interval_seconds = 120
+        mock_config.write_mode = True
+        mock_config.write_budget_max = 100
+        mock_config.write_budget_window_seconds = 60
         mock_get_config.return_value = mock_config
 
         # Initialize cache

--- a/tests/test_note_creation.py
+++ b/tests/test_note_creation.py
@@ -11,6 +11,17 @@ from simplenote_mcp.server.cache import NoteCache
 from simplenote_mcp.tests.test_helpers import helper_handle_call_tool
 
 
+@pytest.fixture(autouse=True)
+def enable_write_mode():
+    """Enable write mode for all tests in this module."""
+    import simplenote_mcp.server.config as _cfg
+
+    _cfg._config = None
+    with patch.dict("os.environ", {"SIMPLENOTE_WRITE_MODE": "true"}):
+        yield
+    _cfg._config = None
+
+
 @pytest.fixture
 def mock_simplenote_client():
     """Create a mock Simplenote client for note creation tests."""

--- a/tests/test_server_advanced.py
+++ b/tests/test_server_advanced.py
@@ -36,36 +36,45 @@ class TestMCPProtocolHandlers:
 
     @pytest.mark.asyncio
     async def test_handle_list_tools_full_coverage(self):
-        """Test handle_list_tools to cover all tool definitions."""
+        """Test handle_list_tools in both read-only and write-mode."""
+        # --- read-only mode (default) ---
         result = await handle_list_tools()
-
         assert isinstance(result, list)
-        assert len(result) >= 7  # Should have at least 7 tools
+        tool_names = [t.name for t in result]
 
-        # Verify all expected tools are present
-        tool_names = [tool.name for tool in result]
-        expected_tools = [
-            "create_note",
-            "update_note",
-            "get_note",
-            "delete_note",
-            "search_notes",
-            "add_tags",
-            "remove_tags",
-            "replace_tags",
-        ]
+        read_only_tools = ["list_notes", "search_notes", "get_note", "list_tags"]
+        for expected in read_only_tools:
+            assert expected in tool_names, f"{expected} missing in read-only mode"
 
-        for expected in expected_tools:
-            assert expected in tool_names
+        write_tools = ["create_note", "update_note", "delete_note"]
+        for write_tool in write_tools:
+            assert write_tool not in tool_names, (
+                f"{write_tool} should not appear in read-only mode"
+            )
 
-        # Verify tool structure
-        for tool in result:
+        # --- write mode ---
+        import simplenote_mcp.server.config as _cfg
+
+        _cfg._config = None
+        try:
+            with patch.dict("os.environ", {"SIMPLENOTE_WRITE_MODE": "true"}):
+                result_write = await handle_list_tools()
+        finally:
+            _cfg._config = None  # Always restore so later tests get a clean config
+
+        write_tool_names = [t.name for t in result_write]
+        for expected in ["create_note", "update_note", "delete_note", "search_notes"]:
+            assert expected in write_tool_names, f"{expected} missing in write mode"
+
+        # Verify tool structure for all tools
+        for tool in result_write:
             assert hasattr(tool, "name")
             assert hasattr(tool, "description")
             assert hasattr(tool, "inputSchema")
             assert isinstance(tool.inputSchema, dict)
             assert "type" in tool.inputSchema
             assert "properties" in tool.inputSchema
+            assert tool.annotations is not None, f"{tool.name} is missing annotations"
 
     @pytest.mark.asyncio
     async def test_handle_list_prompts_full_coverage(self):
@@ -130,10 +139,16 @@ class TestMCPProtocolHandlers:
         # Mock tool registry to return our handler
         from simplenote_mcp.server.tool_handlers import ToolHandlerRegistry
 
+        mock_config = Mock()
+        mock_config.write_mode = True
+        mock_config.write_budget_max = 100
+        mock_config.write_budget_window_seconds = 60
+
         with (
             patch.object(ToolHandlerRegistry, "get_handler", return_value=mock_handler),
             patch("simplenote_mcp.server.server.get_simplenote_client"),
             patch("simplenote_mcp.server.server.note_cache"),
+            patch("simplenote_mcp.server.server.get_config", return_value=mock_config),
         ):
             result = await handle_call_tool("create_note", {"content": "Test note"})
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -227,7 +227,7 @@ class TestHandleListTools:
 
     @pytest.mark.asyncio
     async def test_returns_tool_list_normally(self):
-        """handle_list_tools returns a non-empty list of Tool objects."""
+        """handle_list_tools returns read-only tools without write_mode."""
         import simplenote_mcp.server.server as srv
 
         result = await srv.handle_list_tools()
@@ -235,12 +235,34 @@ class TestHandleListTools:
         assert isinstance(result, list)
         assert len(result) >= 2
         names = [t.name for t in result]
+        # Read-only tools are always present
+        assert "search_notes" in names
+        assert "list_notes" in names
+        assert "get_note" in names
+        # Write tools are absent when write_mode is off (the default)
+        assert "create_note" not in names
+
+    @pytest.mark.asyncio
+    async def test_returns_write_tools_when_write_mode_enabled(self):
+        """handle_list_tools includes write tools when SIMPLENOTE_WRITE_MODE=true."""
+        import simplenote_mcp.server.config as _cfg
+        import simplenote_mcp.server.server as srv
+
+        _cfg._config = None
+        try:
+            with patch.dict("os.environ", {"SIMPLENOTE_WRITE_MODE": "true"}):
+                result = await srv.handle_list_tools()
+        finally:
+            _cfg._config = None
+
+        names = [t.name for t in result]
         assert "create_note" in names
+        assert "update_note" in names
         assert "search_notes" in names
 
     @pytest.mark.asyncio
     async def test_exception_falls_back_to_core_tools(self):
-        """When an unexpected error occurs only the core tools are returned."""
+        """When an unexpected error occurs only the fallback tool is returned."""
         import simplenote_mcp.server.server as srv
 
         # Patch the logger.info used at the start of the try-block to raise
@@ -250,7 +272,6 @@ class TestHandleListTools:
             result = await srv.handle_list_tools()
 
         names = [t.name for t in result]
-        assert "create_note" in names
         assert "search_notes" in names
 
 

--- a/tests/test_tool_handlers.py
+++ b/tests/test_tool_handlers.py
@@ -46,6 +46,7 @@ class TestToolHandlerRegistry:
             "update_note",
             "delete_note",
             "get_note",
+            "list_notes",
             "search_notes",
             "add_tags",
             "remove_tags",

--- a/tests/test_tool_handlers_additional.py
+++ b/tests/test_tool_handlers_additional.py
@@ -358,6 +358,7 @@ class TestToolHandlerRegistryComplete:
             "update_note",
             "delete_note",
             "get_note",
+            "list_notes",
             "search_notes",
             "add_tags",
             "remove_tags",
@@ -383,7 +384,7 @@ class TestToolHandlerRegistryComplete:
         ]
 
         assert set(tools) == set(expected_tools)
-        assert len(tools) == 26
+        assert len(tools) == 27
 
     def test_get_handler_types(self):
         """Test getting handlers of different types."""


### PR DESCRIPTION
## Summary

Improvements inspired by comparing with Automattic's official Simplenote MCP server:

- **MCP tool annotations** — all 27 tools now carry `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` so clients (Claude Desktop, Cursor, etc.) can surface safer defaults
- **Write-mode gate** — write tools are hidden from `list_tools` and blocked at call time unless `SIMPLENOTE_WRITE_MODE=true`; returns a structured error otherwise
- **Write-budget counter** — rolling 60-second window (default 20 writes) with per-session deque; prevents runaway bulk operations and prompts the user to confirm before retrying
- **`list_notes` tool** — new read-only tool that lists notes with optional tag filter, pinned-first sort, and configurable limit (max 100)
- **Content-shrink guard** — `update_note` rejects replacements that are <20% of the original length (for notes ≥200 chars), directing the LLM to use `add_text` or `replace_section` instead
- **No-op revert detection** — `restore_version` skips the write when the target version's content matches the current cached content, returning `no_op: true`
- **Docs** — `.env.example` now documents `SIMPLENOTE_WRITE_MODE`

## Test plan

- [ ] `SIMPLENOTE_OFFLINE_MODE=true pytest tests/ -x -q --timeout=30` passes (all 3 commits clean)
- [ ] Write tools absent from `list_tools` response when `SIMPLENOTE_WRITE_MODE` is unset
- [ ] Write tools present and callable after setting `SIMPLENOTE_WRITE_MODE=true`
- [ ] `update_note` returns `suspicious_shrink` error when replacing 200+ char note with <20% content
- [ ] `restore_version` returns `no_op: true` when version matches current cache
- [ ] `list_notes` returns pinned-first note list, respects `tag` and `limit` parameters
- [ ] Write budget exhausted message after 20 writes in 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Gate Simplenote MCP write tools behind an opt-in write mode with per-session write budgeting, enrich all tools with safety annotations, add a new list_notes browsing tool, and harden write operations with shrink/no-op guards and updated tests/docs.

New Features:
- Add MCP tool annotations (read-only, destructive, idempotent, open-world hints) to all exposed tools so clients can reflect safer defaults.
- Introduce a list_notes tool for browsing recent notes with optional tag filtering, pinned-first sorting, and configurable limits.

Enhancements:
- Hide all write-capable tools from list_tools by default and only expose them when SIMPLENOTE_WRITE_MODE is enabled.
- Implement a per-session rolling write-budget that limits the number of write operations within a configurable time window.
- Add safeguards to update_note to reject suspiciously large content shrinks and to restore_version to skip writes when the target version matches the current content.
- Ensure tool registry and server logging reflect the new tool set and write-mode behavior.

Documentation:
- Document SIMPLENOTE_WRITE_MODE and write-mode behavior in .env.example.

Tests:
- Expand server and handler tests to cover read-only vs write-mode tool visibility, write-mode toggling via environment variables, write budget reset between tests, and the new list_notes handler.
- Adjust existing tests and fixtures to operate with write mode and write budget configuration where needed, and update registry completeness assertions.