### PR TITLE
fix(ci): resolve health check pytest addopts conflict with cov plugin

### DIFF
--- a/.github/workflows/monitoring-consolidated.yml
+++ b/.github/workflows/monitoring-consolidated.yml
@@ -138,9 +138,10 @@ jobs:
           # Check configuration validation
           python -c "from simplenote_mcp.server.config import get_config; config = get_config(); print('✅ Configuration loads successfully')"
 
-          # Run smoke tests (disable coverage plugin — only test_config.py runs here,
-          # global --cov-fail-under=75 in pyproject.toml would otherwise cause a false failure)
-          python -m pytest tests/test_config.py -v --tb=short -p no:cov
+          # Run smoke tests with addopts cleared — pytest.ini addopts includes --cov* flags
+          # which become unrecognized when the cov plugin is disabled; clearing addopts avoids
+          # the "unrecognized arguments" error while asyncio_mode/timeout remain as standalone keys.
+          python -m pytest tests/test_config.py -v --tb=short --override-ini="addopts="
 
           echo "✅ All health checks passed"
 


### PR DESCRIPTION
## Summary

- The `Health Check Monitoring` job was failing with exit code 4: `unrecognized arguments: --cov=simplenote_mcp --cov-report=... --cov-fail-under=75`
- Root cause: `pytest.ini` `addopts` injects `--cov*` flags; the previous fix used `-p no:cov` to disable the plugin, but with the plugin disabled those addopts become unrecognized arguments
- Fix: use `--override-ini="addopts="` to clear the conflicting options for this targeted smoke test — `asyncio_mode` and `timeout` remain effective via their standalone `pytest.ini` keys

## Test plan

- [x] Verified locally: `python -m pytest tests/test_config.py -v --tb=short --override-ini="addopts="` — 63 tests pass, no coverage plugin conflict
- [ ] CI `Consolidated Monitoring` should pass the `Health Check Monitoring` job on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the Health Check Monitoring job to clear pytest addopts via --override-ini for the config smoke test, preventing unrecognized --cov arguments without affecting other pytest settings.