### PR TITLE
chore(ci): add claude-dependabot-merge and claude-status-check reusable callers

### DIFF
--- a/.github/workflows/claude-dependabot-merge.yml
+++ b/.github/workflows/claude-dependabot-merge.yml
@@ -1,0 +1,56 @@
+# .github/workflows/claude-dependabot-merge.yml
+#
+# Thin caller that delegates to the reusable workflow in docdyhr/.github.
+# Replaces the previous ~27 KB inline implementation.
+#
+# Schedule is owned by the cross-repo orchestrator in docdyhr/.github.
+# To upgrade the reusable workflow across all consumers, bump the @v1 ref in
+# docdyhr/.github (re-tag) — this caller automatically picks it up on next run.
+
+name: Claude Dependabot Auto-Merge
+
+on:
+  push:
+    paths:
+      - ".github/workflows/claude-dependabot-merge.yml"
+
+  workflow_dispatch:
+    inputs:
+      merge_mode:
+        description: "dry-run = report only; live = actually merge passing PRs"
+        type: choice
+        options: [dry-run, live]
+        default: dry-run
+        required: true
+      scope:
+        description: "all | security | patch"
+        type: choice
+        options: [all, security, patch]
+        default: all
+        required: false
+      max_budget_usd:
+        description: "Maximum Claude API spend in USD for this run"
+        type: string
+        default: "0.30"
+        required: false
+      pr_numbers:
+        description: "Comma-separated PR numbers (blank = all open Dependabot PRs)"
+        type: string
+        default: ""
+        required: false
+
+jobs:
+  call-reusable:
+    uses: docdyhr/.github/.github/workflows/claude-dependabot-merge.yml@v1
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      checks: read
+      statuses: read
+    secrets: inherit
+    with:
+      merge_mode: ${{ github.event.inputs.merge_mode || 'dry-run' }}
+      scope: ${{ github.event.inputs.scope || 'all' }}
+      max_budget_usd: ${{ github.event.inputs.max_budget_usd || '0.30' }}
+      pr_numbers: ${{ github.event.inputs.pr_numbers || '' }}

--- a/.github/workflows/claude-status-check.yml
+++ b/.github/workflows/claude-status-check.yml
@@ -1,0 +1,52 @@
+# .github/workflows/claude-status-check.yml
+#
+# Thin caller that delegates to the reusable workflow in docdyhr/.github.
+# Replaces the previous ~21 KB inline implementation.
+#
+# Schedule is owned by the cross-repo orchestrator in docdyhr/.github.
+# To upgrade the reusable workflow across all consumers, bump the @v1 ref in
+# docdyhr/.github (re-tag) — this caller automatically picks it up on next run.
+
+name: Claude Status Check
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/claude-status-check.yml"
+
+  workflow_dispatch:
+    inputs:
+      create_issue:
+        description: "Create a GitHub issue if health is CRITICAL"
+        type: boolean
+        default: false
+        required: false
+      max_budget_usd:
+        description: "Maximum Claude API spend in USD"
+        type: string
+        default: "0.25"
+        required: false
+      sections:
+        description: "Comma-separated sections to check (prs,ci,issues,dependabot,branches) or 'all'"
+        type: string
+        default: "all"
+        required: false
+
+concurrency:
+  group: claude-status-check
+  cancel-in-progress: false
+
+jobs:
+  call-reusable:
+    uses: docdyhr/.github/.github/workflows/claude-status-check.yml@v1
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    secrets: inherit
+    with:
+      create_issue: ${{ github.event.inputs.create_issue == 'true' }}
+      max_budget_usd: ${{ github.event.inputs.max_budget_usd || '0.25' }}
+      sections: ${{ github.event.inputs.sections || 'all' }}


### PR DESCRIPTION
Brings `simplenote-mcp-server` in line with the docdyhr org standard by adding the two reusable-workflow callers that every other T1/T2 repo has.

## What and why

- `claude-dependabot-merge.yml` — thin caller to `docdyhr/.github/.github/workflows/claude-dependabot-merge.yml@v1`. `workflow_dispatch` only (no schedule — the orchestrator in `docdyhr/.github` owns scheduling).
- `claude-status-check.yml` — thin caller to `docdyhr/.github/.github/workflows/claude-status-check.yml@v1`. Same pattern.

Both callers fire on `push` to themselves so the reusable smoke-test runs on merge.

## What is NOT changed

All 12 existing workflows are untouched. The evaluation (`evaluation-quality-gate.yml`, `mcp-evaluations.yml`), monitoring (`monitoring-consolidated.yml`), and `auto-merge.yml` are legitimately project-specific and stay as inline definitions.

## Summary by Sourcery

Add reusable workflow callers for Claude-powered Dependabot auto-merge and status checks, delegating to shared org-level workflows.

CI:
- Introduce claude-dependabot-merge workflow that delegates Dependabot auto-merge operations to the shared docdyhr/.github reusable workflow.
- Add claude-status-check workflow that calls the shared docdyhr/.github reusable status-check workflow with configurable inputs and concurrency settings.