### PR TITLE
fix: scope claude-dependabot-merge push trigger to main branch only

### DIFF
--- a/.github/workflows/claude-dependabot-merge.yml
+++ b/.github/workflows/claude-dependabot-merge.yml
@@ -11,6 +11,8 @@ name: Claude Dependabot Auto-Merge
 
 on:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/claude-dependabot-merge.yml"
 


### PR DESCRIPTION
## Summary

- Tag pushes (e.g. `v1.17.0`) were triggering the `Claude Dependabot Auto-Merge` workflow in a context where `ANTHROPIC_API_KEY` is unavailable
- The reusable workflow's safety gate requires the secret, causing the job to fail with _"Secret ANTHROPIC_API_KEY is required, but not provided while calling"_
- Fix: add `branches: [main]` to the `push` trigger so only changes pushed to `main` fire the workflow — tag pushes are excluded

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, push a test tag and confirm `Claude Dependabot Auto-Merge` does **not** trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Limit the Claude Dependabot auto-merge GitHub Actions workflow push trigger to the main branch to avoid runs on tag pushes.