### PR TITLE
feat: fix MCP Resources metadata loss, add session-handoff prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`session-handoff` MCP Prompt**: scaffolds the Session Continuity workflow — takes `project`
+  (required) plus optional `status`/`next_steps`/`blockers`, and returns instructions to call
+  `get_or_create_note` + `add_text` with the canonical `Status:`/`Next:`/`Blockers:` format used
+  for cross-session handoff notes. 3 prompts total (was 2).
+
 ### Fixed
+- **MCP Resources silently dropped tags/dates/pagination metadata**: `handle_list_resources` and
+  `handle_read_resource` computed this metadata and attached it via bare dynamic attributes
+  (`resource.tags = ...`) that aren't part of the `Resource`/`TextResourceContents` schema — a
+  spec-compliant client has no obligation to preserve unrecognized top-level fields. Now attached
+  via the MCP spec's dedicated `_meta` extension field, the correct mechanism for this. The first
+  resource in a `list_resources` page also now carries `pagination` in its `_meta`, fulfilling a
+  contract the docstring already documented but the code never delivered. Tag/date info
+  additionally folds into the human-readable `description` string for clients that only render
+  that field.
 - **Tag-space sanitization inconsistency**: `add_tags` and `remove_tags` called the shared
   `_parse_tags()` sanitizer and discarded its result, then rebuilt the tag list via a separate,
   unsanitized path — `add_tags(tags="my tag")` stored `"my tag"` verbatim while
@@ -49,6 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ROADMAP.md`/`TODO.md` refreshed to the current tool count (27) and version (1.17.1), with the
   next roadmap phases (correctness hardening, opt-in client-side note encryption, companion
   architecture layer) added.
+- `ROADMAP.md`/`TODO.md`: documented the outcome of the `simplenote://recent` auto-context
+  resource spike — investigated and decided against building it. MCP Resources in Claude Desktop
+  are user-attached, not auto-loaded into a conversation at session start, so a curated resource
+  wouldn't deliver the "automatic" value the idea was chasing. The existing tool-based path
+  (`search_notes`/`get_or_create_note`, now paired with the `session-handoff` prompt) already
+  solves proactive context-pulling, since tools — unlike resources — are always available for the
+  model to call on its own initiative.
 
 ## [1.17.1] - 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,20 @@ This allows Claude Desktop to interact with your Simplenote notes as a memory ba
 
 ## What's New
 
-**27 Tools — Full Bear Parity + Simplenote Differentiators + Claude Companion Tools**
+**27 Tools + 3 Prompts — Full Bear Parity + Simplenote Differentiators + Claude Companion Tools**
+
+MCP Resources and Prompts hardened for the working-memory companion use case:
+
+- **Fixed**: `list_resources`/`read_resource` were silently dropping tag/date/pagination metadata via non-schema fields — now attached through the MCP spec's `_meta` extension field, the correct mechanism.
+- **`session-handoff` MCP Prompt**: scaffolds the Session Continuity workflow (`get_or_create_note` + `add_text` with a `Status:`/`Next:`/`Blockers:` format) for cross-session context handoff.
 
 Irreversible-deletion tools with mandatory safety guards:
 
 - **`permanent_delete_note`**: Permanently destroy a single note; requires `confirm=true`; dry-run preview by default
 - **`empty_trash`**: Permanently delete all trashed notes; defaults to `dry_run=true` (preview); requires `dry_run=false` AND `confirm=true`
-- **1227 tests passing**, 77%+ coverage, zero linting/type errors
+- **1231 tests passing**, 77%+ coverage, zero linting/type errors
 
-**In progress**: correctness hardening (tag-sanitization consistency, search result limits, background-sync indexing) and an opt-in, client-side note-encryption feature ("Vault") to close Simplenote's lack of encryption-at-rest for sensitive notes. See [ROADMAP.md](ROADMAP.md).
+**Also in flight** (separate PR): an opt-in, client-side note-encryption feature ("Vault") to close Simplenote's lack of encryption-at-rest for sensitive notes. See [ROADMAP.md](ROADMAP.md).
 
 ### v1.17.0
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,11 +134,11 @@ Simplenote has **no encryption at rest** — Automattic's own docs confirm staff
 
 Full design lives in `docs/security/encryption-design.md` (added alongside implementation).
 
-### Phase 10 — Companion Architecture Layer
+### Phase 10 — Companion Architecture Layer ✅ (v1.20, unreleased)
 
-- Fix MCP Resources (`simplenote://note/{id}`) so tags/pagination metadata actually reach clients — today they're computed then attached via non-schema fields and silently dropped.
-- Add native MCP Prompts beyond the current 2 static ones (e.g. a `session-handoff` prompt for the Session Continuity workflow below).
-- Spike (not committed): a curated resource Claude Desktop could auto-surface at conversation start, e.g. `simplenote://recent`.
+- **Fixed MCP Resources metadata loss**: `handle_list_resources`/`handle_read_resource` previously attached tags/dates/pagination via bare dynamic attributes (`resource.tags = ...`) — not part of the `Resource`/`TextResourceContents` schema, so a spec-compliant client has no obligation to preserve them even though this project's own Pydantic models happened to (`extra = "allow"`). Now attached via the MCP spec's dedicated `_meta` extension field, the correct mechanism for exactly this case. The first resource in a `list_resources` page also carries `pagination` in its `_meta`, fulfilling a contract the docstring already promised but the code never delivered. Tag/date info additionally folds into the human-readable `description` string for clients that only render that.
+- **Added `session-handoff` MCP Prompt**: scaffolds the Session Continuity workflow — takes `project` (required) plus optional `status`/`next_steps`/`blockers`, and returns instructions to call `get_or_create_note` + `add_text` with the canonical `Status:`/`Next:`/`Blockers:` format. 3 prompts total now (was 2).
+- **Spike: `simplenote://recent`-style auto-context resource — investigated, not building it.** MCP Resources in Claude Desktop are user-attached (picker/attachment UI), not automatically loaded into a conversation at session start — there's no mechanism in the MCP spec or Claude Desktop's client behavior for a server to push a resource into context proactively. A resource the user has to manually attach every session doesn't deliver the "automatic" value the original idea was chasing. The tool-based path (`search_notes`/`get_or_create_note`, now paired with the `session-handoff` prompt) already lets Claude *pull* project-state context autonomously at the start of a conversation, since tools — unlike resources — are always available for the model to call on its own initiative. That's the actual solution to this problem; a curated resource would be redundant with it.
 
 ### v2.0 Horizon
 

--- a/TODO.md
+++ b/TODO.md
@@ -245,13 +245,11 @@ Simplenote has no encryption at rest (confirmed via Automattic's own docs — se
 - [ ] `[P2]` **`tests/test_vault.py`**: round-trip, tamper detection (flipped byte → raises, never garbage), missing-key behavior, malformed-envelope parsing, key-provider fallback chain
 - [ ] `[P2]` **`LIVE_TESTING.md`** entries for the new vault tools (keychain-prompt UX needs a real Claude Desktop session, not just unit tests)
 
-## v1.20 — Companion Architecture Layer (Phase 10)
+## v1.20 — Companion Architecture Layer (Phase 10) ✅
 
-Lower priority, sequenced last on purpose.
-
-- [ ] `[P2]` **Fix MCP Resources metadata loss** — `handle_list_resources`/`handle_read_resource` (`server.py:614-814`) compute tags/pagination then attach them via non-schema `types.Resource` attributes that are silently dropped before reaching any real client. Fold into the real `description` field instead.
-- [ ] `[P3]` **Add a `session-handoff` MCP Prompt** scaffolding the Session Continuity workflow format (see ROADMAP.md workflow table)
-- [ ] `[P3]` **Spike**: a curated `simplenote://recent`-style resource for conversation-start auto-context — depends on Claude Desktop's client-side resource-attachment behavior, verify feasibility before committing
+- [x] `[P2]` **Fix MCP Resources metadata loss** — tags/dates/pagination now attached via the MCP spec's `_meta` field (correct extension mechanism) instead of non-schema dynamic attributes; also folded into `description` for clients that only render that.
+- [x] `[P3]` **Add a `session-handoff` MCP Prompt** scaffolding the Session Continuity workflow format (see ROADMAP.md workflow table)
+- [x] `[P3]` **Spike**: a curated `simplenote://recent`-style resource for conversation-start auto-context — **investigated, decided not to build**: MCP Resources in Claude Desktop are user-attached, not auto-loaded at session start; the tool-based path (`search_notes`/`get_or_create_note` + the new `session-handoff` prompt) already solves proactive context-pulling since tools, unlike resources, are always available for the model to call on its own initiative. See ROADMAP.md Phase 10 for full reasoning.
 
 ---
 

--- a/simplenote_mcp/server/server.py
+++ b/simplenote_mcp/server/server.py
@@ -706,23 +706,37 @@ async def handle_list_resources(
         )
 
         resources = []
-        for note in notes:
+        for index, note in enumerate(notes):
             note.setdefault("tags", [])
             tags = note["tags"]
             content = note.get("content", "")
+            modifydate = note.get("modifydate", "unknown date")
+            description = f"Note from {modifydate}"
+            if tags:
+                description += f" — tags: {', '.join(tags)}"
+
+            # Tags/dates and (on the first resource) pagination info are
+            # attached via the MCP spec's `_meta` extension field — the only
+            # part of the Resource schema clients are guaranteed to preserve.
+            # Bare dynamic attributes (the previous approach) aren't part of
+            # the schema, so a spec-compliant client has no obligation to
+            # keep them even though this server's own Pydantic models are
+            # permissive enough to hold them locally.
+            meta: dict[str, Any] = {
+                "tags": tags,
+                "modifydate": note.get("modifydate", ""),
+                "createdate": note.get("createdate", ""),
+            }
+            if index == 0:
+                meta["pagination"] = pagination_info
+
             resource = types.Resource(
                 uri=cast(Any, f"simplenote://note/{note['key']}"),
                 name=extract_title_from_content(content, note.get("key", "")),
-                description=f"Note from {note.get('modifydate', 'unknown date')}",
+                description=description,
+                _meta=meta,
             )
-            # Store additional metadata as dynamic attributes (ignore type checking)
-            resource.key = note.get("key")  # type: ignore
-            resource.content = content  # type: ignore
-            resource.tags = tags  # type: ignore
             resources.append(resource)
-
-        # Note: Pagination info is available in pagination_info variable
-        # but cannot be attached to Resource objects directly
 
         return resources
 
@@ -799,18 +813,22 @@ async def handle_read_resource(uri: AnyUrl) -> types.ReadResourceResult:
 
         # Extract note data - only process the note once
         note_content = safe_get(note, "content", "")
-        safe_get(note, "tags", [])
-        safe_get(note, "modifydate", "")
-        safe_get(note, "createdate", "")
+        note_tags = safe_get(note, "tags", [])
+        note_modifydate = safe_get(note, "modifydate", "")
+        note_createdate = safe_get(note, "createdate", "")
 
-        # Create the resource contents object
+        # Tags/dates are attached via the MCP spec's `_meta` extension field —
+        # see the matching comment in handle_list_resources for why this
+        # replaces the previous non-schema dynamic-attribute approach.
         text_contents = types.TextResourceContents(
             text=note_content,
             uri=cast(Any, note_uri),
+            _meta={
+                "tags": note_tags,
+                "modifydate": note_modifydate,
+                "createdate": note_createdate,
+            },
         )
-
-        # Note: Metadata like tags, dates available in local variables
-        # but cannot be attached to TextResourceContents objects directly
 
         return types.ReadResourceResult(contents=[text_contents])
 
@@ -1678,6 +1696,37 @@ async def handle_list_prompts() -> list[types.Prompt]:
                 )
             ],
         ),
+        types.Prompt(
+            name="session_handoff_prompt",
+            description=(
+                "Scaffold a session handoff note so the next Claude session can pick "
+                "up where this one left off. Uses get_or_create_note + add_text to "
+                "append a structured, timestamped entry to a per-project note — "
+                "Simplenote MCP's Session Continuity workflow."
+            ),
+            arguments=[
+                types.PromptArgument(
+                    name="project",
+                    description="Project or topic name — becomes part of the note title",
+                    required=True,
+                ),
+                types.PromptArgument(
+                    name="status",
+                    description="What was done / current state this session",
+                    required=False,
+                ),
+                types.PromptArgument(
+                    name="next_steps",
+                    description="What to do at the start of the next session",
+                    required=False,
+                ),
+                types.PromptArgument(
+                    name="blockers",
+                    description="Anything blocking progress (default: none)",
+                    required=False,
+                ),
+            ],
+        ),
     ]
 
 
@@ -1745,6 +1794,49 @@ async def handle_get_prompt(
                     content=types.TextContent(
                         type="text",
                         text=f"Please search for notes matching the query: {query}",
+                    ),
+                ),
+            ],
+        )
+
+    elif name == "session_handoff_prompt":
+        project = arguments.get("project", "")
+        status = arguments.get("status", "") or "<what was done / current state>"
+        next_steps = arguments.get("next_steps", "") or "<what to do next session>"
+        blockers = arguments.get("blockers", "") or "none"
+
+        return types.GetPromptResult(
+            description="Write a session handoff note for cross-session continuity",
+            messages=[
+                types.PromptMessage(
+                    role="user",
+                    content=types.TextContent(
+                        type="text",
+                        text=(
+                            "You are ending a working session and writing a handoff "
+                            "note so a future Claude session can pick up where this "
+                            "one left off. This is Simplenote MCP's Session "
+                            "Continuity workflow: find or create a per-project note, "
+                            "then append a timestamped entry."
+                        ),
+                    ),
+                ),
+                types.PromptMessage(
+                    role="user",
+                    content=types.TextContent(
+                        type="text",
+                        text=(
+                            f'1. Call get_or_create_note with title="Project: '
+                            f'{project}" and tags=["project-active"] to find or '
+                            f"create the project's state note.\n"
+                            f'2. Call add_text on that note (position="end") with '
+                            f"an entry in this format:\n\n"
+                            f"Status: {status}\n"
+                            f"Next: {next_steps}\n"
+                            f"Blockers: {blockers}\n\n"
+                            "Keep each field to one or two sentences — this note is "
+                            "read at the start of the next session, not a full log."
+                        ),
                     ),
                 ),
             ],

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -17,7 +17,7 @@ class TestPromptCapabilities:
         prompts = await handle_list_prompts()
 
         # Verify prompt count
-        assert len(prompts) == 2
+        assert len(prompts) == 3
 
         # Verify first prompt (create_note_prompt)
         create_prompt = prompts[0]
@@ -36,6 +36,15 @@ class TestPromptCapabilities:
         assert len(search_prompt.arguments) == 1
         assert search_prompt.arguments[0].name == "query"
         assert search_prompt.arguments[0].required is True
+
+        # Verify third prompt (session_handoff_prompt)
+        handoff_prompt = prompts[2]
+        assert handoff_prompt.name == "session_handoff_prompt"
+        assert len(handoff_prompt.arguments) == 4
+        arg_names = [a.name for a in handoff_prompt.arguments]
+        assert arg_names == ["project", "status", "next_steps", "blockers"]
+        assert handoff_prompt.arguments[0].required is True
+        assert all(not a.required for a in handoff_prompt.arguments[1:])
 
     async def test_get_prompt_create_note(self):
         """Test getting the create_note_prompt."""
@@ -91,6 +100,53 @@ class TestPromptCapabilities:
                 mock_result.call_args[1]["description"]
                 == "Search for notes in Simplenote"
             )
+
+    async def test_get_prompt_session_handoff(self):
+        """Test getting the session_handoff_prompt."""
+        with (
+            patch("mcp.types.PromptMessage") as mock_prompt_message,
+            patch("mcp.types.TextContent") as mock_text_content,
+            patch("mcp.types.GetPromptResult") as mock_result,
+        ):
+            mock_text_content.return_value = MagicMock()
+            mock_prompt_message.return_value = MagicMock()
+            mock_result.return_value = MagicMock()
+
+            await handle_get_prompt(
+                "session_handoff_prompt",
+                {
+                    "project": "drop2md",
+                    "status": "Secrets configured",
+                    "next_steps": "Test the release workflow",
+                    "blockers": "none",
+                },
+            )
+
+            mock_result.assert_called_once()
+            assert mock_prompt_message.call_count == 2
+            assert (
+                mock_result.call_args[1]["description"]
+                == "Write a session handoff note for cross-session continuity"
+            )
+
+    async def test_get_prompt_session_handoff_content(self):
+        """session_handoff_prompt must reference get_or_create_note/add_text
+        and the project name, and fill sensible placeholders for optional
+        arguments that weren't provided."""
+        result = await handle_get_prompt(
+            "session_handoff_prompt", {"project": "drop2md"}
+        )
+
+        assert result.description == (
+            "Write a session handoff note for cross-session continuity"
+        )
+        combined_text = " ".join(
+            msg.content.text for msg in result.messages if hasattr(msg.content, "text")
+        )
+        assert "get_or_create_note" in combined_text
+        assert "add_text" in combined_text
+        assert "drop2md" in combined_text
+        assert "Blockers: none" in combined_text
 
     async def test_get_prompt_missing_arguments(self):
         """Test getting a prompt with missing arguments."""

--- a/tests/test_prompts_capabilities.py
+++ b/tests/test_prompts_capabilities.py
@@ -15,7 +15,7 @@ class TestPromptCapabilities:
         prompts = await handle_list_prompts()
 
         # Verify prompt count
-        assert len(prompts) == 2
+        assert len(prompts) == 3
 
         # Verify first prompt (create_note_prompt)
         create_prompt = prompts[0]

--- a/tests/test_server_advanced.py
+++ b/tests/test_server_advanced.py
@@ -235,6 +235,13 @@ class TestMCPProtocolHandlers:
         assert len(result.contents[0].text) > 0
         assert "Test note content with metadata" in result.contents[0].text
 
+        # Tags/dates must be attached via the schema's `_meta` field, not
+        # bare dynamic attributes (regression test for the metadata-loss fix).
+        meta = result.contents[0].meta
+        assert meta["tags"] == ["important", "work"]
+        assert meta["createdate"] == "2023-01-01T10:00:00Z"
+        assert meta["modifydate"] == "2023-01-02T15:30:00Z"
+
     @pytest.mark.asyncio
     async def test_handle_list_resources_integration(self):
         """Test complete resource listing integration with proper structure validation."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -383,16 +383,29 @@ class TestHandleListPrompts:
     """Tests for handle_list_prompts."""
 
     @pytest.mark.asyncio
-    async def test_returns_two_prompts(self):
-        """handle_list_prompts returns exactly two prompts."""
+    async def test_returns_three_prompts(self):
+        """handle_list_prompts returns exactly three prompts."""
         import simplenote_mcp.server.server as srv
 
         result = await srv.handle_list_prompts()
 
-        assert len(result) == 2
+        assert len(result) == 3
         names = [p.name for p in result]
         assert "create_note_prompt" in names
         assert "search_notes_prompt" in names
+        assert "session_handoff_prompt" in names
+
+    @pytest.mark.asyncio
+    async def test_session_handoff_prompt_has_required_project_arg(self):
+        """session_handoff_prompt declares a required 'project' argument."""
+        import simplenote_mcp.server.server as srv
+
+        result = await srv.handle_list_prompts()
+        handoff_prompt = next(p for p in result if p.name == "session_handoff_prompt")
+
+        required_args = [a for a in handoff_prompt.arguments if a.required]
+        names = [a.name for a in required_args]
+        assert names == ["project"]
 
     @pytest.mark.asyncio
     async def test_create_note_prompt_has_required_content_arg(self):
@@ -424,7 +437,7 @@ class TestHandleListPrompts:
 
 
 class TestHandleGetPrompt:
-    """Tests for all three branches of handle_get_prompt."""
+    """Tests for all four branches of handle_get_prompt."""
 
     @pytest.mark.asyncio
     async def test_create_note_prompt_returns_two_messages(self):

--- a/tests/test_server_working.py
+++ b/tests/test_server_working.py
@@ -46,6 +46,59 @@ class TestWorkingFunctions:
         assert len(result) >= 2  # May include pagination metadata
 
     @pytest.mark.asyncio
+    async def test_handle_list_resources_attaches_tags_dates_via_meta(self):
+        """Regression test: tags/dates/pagination were previously attached via
+        bare dynamic attributes (resource.tags = ...) that aren't part of the
+        MCP Resource schema — a spec-compliant client has no obligation to
+        preserve them. They must go through the schema's `_meta` extension
+        field instead.
+        """
+        mock_note_cache = Mock()
+        mock_notes = [
+            {
+                "key": "note1",
+                "content": "Title One\nBody text",
+                "tags": ["work", "urgent"],
+                "modifydate": "2023-01-01",
+                "createdate": "2022-12-01",
+            },
+            {
+                "key": "note2",
+                "content": "Title Two\nMore body",
+                "tags": [],
+                "modifydate": "2023-01-02",
+                "createdate": "2022-12-02",
+            },
+        ]
+        mock_note_cache.get_all_notes.return_value = mock_notes
+        mock_note_cache.get_pagination_info.return_value = {
+            "total": 2,
+            "page": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+        with patch("simplenote_mcp.server.server.note_cache", mock_note_cache):
+            result = await handle_list_resources()
+
+        assert len(result) == 2
+        first, second = result
+
+        assert first.meta["tags"] == ["work", "urgent"]
+        assert first.meta["modifydate"] == "2023-01-01"
+        assert first.meta["createdate"] == "2022-12-01"
+        assert "urgent" in first.description
+
+        # Pagination info is documented to live on the first resource only.
+        assert first.meta["pagination"]["total"] == 2
+        assert "pagination" not in second.meta
+
+        # No leftover non-schema dynamic attributes from the old approach.
+        assert not hasattr(first, "key")
+        assert not hasattr(first, "content")
+        assert not hasattr(first, "tags")
+
+    @pytest.mark.asyncio
     async def test_handle_list_resources_no_cache(self):
         """Test handle_list_resources when cache is None."""
         with patch("simplenote_mcp.server.server.note_cache", None):


### PR DESCRIPTION
## Description

Phase 10 (companion architecture layer) — the last of three phases from this session's roadmap work (see #694, #695).

**Fixed:**
`handle_list_resources`/`handle_read_resource` computed tags/dates/pagination metadata and attached it via bare dynamic attributes (`resource.tags = ...`) that aren't part of the `Resource`/`TextResourceContents` schema. Verified directly against the installed `mcp` SDK (v1.27.0): both models have `model_config = {"extra": "allow"}`, so these attributes happened to survive *local* Pydantic serialization — but that's an implementation accident of this one library version, not a schema guarantee, so a spec-compliant client has no obligation to preserve unrecognized top-level fields. Replaced with the MCP spec's dedicated `_meta` extension field — the correct mechanism for exactly this case — and verified it round-trips correctly through `model_dump_json()`. The first resource in a `list_resources` page now also carries `pagination` in its `_meta`, fulfilling a contract the docstring already documented but the code never delivered. Tag/date info additionally folds into the human-readable `description` string for clients that only render that.

**Added:**
New `session-handoff` MCP Prompt: takes `project` (required) plus optional `status`/`next_steps`/`blockers`, and returns instructions to call `get_or_create_note` + `add_text` with the canonical `Status:`/`Next:`/`Blockers:` format — scaffolding the Session Continuity workflow from the roadmap. 3 prompts total (was 2).

**Investigated, decided not to build:**
A curated `simplenote://recent`-style resource for conversation-start auto-context. MCP Resources in Claude Desktop are user-attached (picker/attachment UI), not automatically loaded into a conversation at session start — there's no mechanism in the MCP spec or Claude Desktop's client behavior for a server to push a resource into context proactively. The tool-based path (`search_notes`/`get_or_create_note`, now paired with `session-handoff`) already lets Claude *pull* project-state context autonomously, since tools — unlike resources — are always available for the model to call on its own initiative. Full reasoning in `ROADMAP.md`'s Phase 10 section.

**Housekeeping found along the way:** four pre-existing test files had hardcoded "exactly 2 prompts" assertions (`test_prompts.py`, `test_prompts_capabilities.py`, `test_server_handlers.py`) that would have broken on the next prompt addition regardless of this PR — updated all of them, plus extended one test (`test_handle_read_resource_with_metadata`) whose name promised metadata verification it never actually did.

## Related Issue
No tracking issue — follow-up to #694 and #695, completing the roadmap from the same planning session (`ROADMAP.md` Phase 10).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing
- [x] Full suite via `.venv/bin/pytest tests/ -x -q --timeout=30` (the exact command the repo's local test hook uses): 1231 passed, 8 skipped, 77%+ coverage (gate: 75%)
- [x] `.venv/bin/ruff check .` / `ruff format --check .` — clean
- [x] `.venv/bin/mypy simplenote_mcp` — no issues in 68 source files
- [x] `.venv/bin/bandit -r simplenote_mcp -c pyproject.toml` — 3 pre-existing low-severity findings, none new, none in touched files
- [x] `make test-fast` (repo's canonical fast-test target) passes
- [x] Verified the `_meta` fix directly against the `mcp` package's actual Pydantic schema and serialization behavior, not just assumption from old code comments

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Follow-up
This completes all three phases planned in this session (#694 merged, #695 open). No further roadmap items are queued after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix MCP resource metadata handling and add a new session handoff prompt to support cross-session continuity workflows.

New Features:
- Introduce a `session-handoff` MCP prompt that guides creating structured handoff notes using existing note tools for cross-session continuity.

Bug Fixes:
- Ensure MCP resources and resource contents consistently expose tags, dates, and pagination via the `_meta` extension field and descriptive text instead of non-schema dynamic attributes that were previously dropped.

Documentation:
- Update README, CHANGELOG, ROADMAP, and TODO to document the new `session-handoff` prompt, the metadata fix for MCP resources, and the decision not to build an auto-context `simplenote://recent` resource.

Tests:
- Extend and add tests to cover `_meta`-based metadata attachment for resources and contents, validate prompt counts and arguments for all three prompts, and verify session-handoff prompt behavior.

Chores:
- Mark Phase 10 (Companion Architecture Layer) tasks as completed and record the outcome of the auto-context resource spike in planning docs.