### PR TITLE
fix: use Bandit-native nosec syntax instead of ruff's noqa for B105

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -9,9 +9,11 @@ skips:
 
 # B105 (hardcoded_password_string) is intentionally NOT skipped — kept active
 # so key-handling code (e.g. simplenote_mcp/server/vault.py) is guarded
-# against accidentally hardcoded secrets. Use a targeted `# noqa: S105` on a
-# specific line if it's a genuine false positive (e.g. an enum value string
-# that merely contains the word "token"), not a blanket skip here.
+# against accidentally hardcoded secrets. Use a targeted `# nosec B105` (the
+# Bandit-native suppression syntax — `# noqa` is a ruff/flake8 convention
+# Bandit does not understand) on a specific line if it's a genuine false
+# positive (e.g. an enum value string that merely contains the word
+# "token"), not a blanket skip here.
 
 # Only report medium and high severity issues
 # confidence:

--- a/simplenote_mcp/server/error_taxonomy.py
+++ b/simplenote_mcp/server/error_taxonomy.py
@@ -18,7 +18,7 @@ class ErrorSubcategory(Enum):
     INVALID_CREDENTIALS = "invalid_credentials"
     EXPIRED_SESSION = "expired_session"
     MISSING_AUTH = "missing_auth"
-    TOKEN_INVALID = "token_invalid"  # noqa: S105
+    TOKEN_INVALID = "token_invalid"  # nosec B105 - enum label, not a credential
     PERMISSION_DENIED = "permission_denied"
 
     # Configuration subcategories


### PR DESCRIPTION
## Description

Fixes a CI break on `main` introduced by #695. The Security Scanning workflow (`.github/workflows/security.yml`) started failing after #695 removed the blanket B105 (hardcoded-password-string) skip to keep secret-detection active for key-handling code (`vault.py`).

`error_taxonomy.py`'s `TOKEN_INVALID` enum value had a pre-existing suppression comment, `# noqa: S105` — but that's ruff/flake8 syntax, not Bandit's. Bandit doesn't understand `# noqa` at all, and this project's ruff config doesn't even have the `S` (flake8-bandit) rule category enabled, so the comment was inert for both tools. It had been silently masked by the blanket B105 skip until #695 removed it, at which point this pre-existing false positive surfaced for real in the `security.yml` CI job — which, unlike `unified-ci.yml`'s inline bandit step, doesn't filter by severity.

**Fix:**
- `error_taxonomy.py`: `# noqa: S105` → `# nosec B105` (Bandit's actual suppression syntax), with a clearer comment
- `.bandit`: corrected the same noqa/nosec mistake in its own guidance comment (written in the same PR that introduced the bug) so it doesn't mislead the next person who hits this

## Related Issue
Fixes the CI failure introduced by #695 on `main` (commit `fc5d127`).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Verified locally by replicating the *exact* failing CI command:
```
bandit -r simplenote_mcp/ --skip B101,B110,B310,B311,B404,B603,B607 \
  --exclude ".venv,simplenote_mcp/tests,simplenote_mcp/scripts,test_*.py"
```
- [x] Before fix: exit 1, `[B105:hardcoded_password_string]` at `error_taxonomy.py:21`
- [x] After fix: `"No issues identified"`, exit 0
- [x] Full suite via `.venv/bin/pytest tests/ -x -q --timeout=30`: 1289 passed, 8 skipped, 78%+ coverage
- [x] `.venv/bin/ruff check .` / `ruff format --check .` — clean
- [x] `.venv/bin/mypy simplenote_mcp` — no issues

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align Bandit suppression syntax in code and Bandit config to correctly ignore the intended hardcoded-password-string false positive without disabling broader secret detection.

Bug Fixes:
- Prevent Bandit B105 false positive on the TOKEN_INVALID error subcategory so security scanning CI passes.

Enhancements:
- Clarify inline guidance on Bandit suppression syntax in code and Bandit configuration comments.