### PR TITLE
fix: read_resource crashed over the real MCP wire protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 27 registered tools → 30 (9 read + 21 write).
 
 ### Fixed
+- **`read_resource` crashed over the real MCP wire protocol**: `handle_read_resource` returned a
+  pre-built `types.ReadResourceResult`, but the SDK's `@server.read_resource()` decorator expects
+  the handler to return `str | bytes | Iterable[ReadResourceContents]` and wraps that into a
+  `ReadResourceResult` itself. Because pydantic `BaseModel` defines `__iter__` (yielding
+  `(field_name, value)` tuples for `.dict()`-style conversion), the decorator's `isinstance(...,
+  Iterable)` check matched the returned `ReadResourceResult` too, then iterated it expecting
+  resource-content objects and got `(field_name, value)` tuples instead — raising
+  `'tuple' object has no attribute 'content'` on every real `read_resource` call. Every unit test
+  for this handler called it directly, bypassing the decorator, so none of them exercised the
+  actual dispatch path — only a live end-to-end run against a real MCP client caught it. Now
+  returns `list[ReadResourceContents]` as the SDK expects; five tests across
+  `tests/test_server_handlers.py`, `tests/test_server_advanced.py`,
+  `tests/test_end_to_end_scenarios.py`, `tests/test_api_interaction.py`, and
+  `tests/test_performance.py` updated to assert the corrected contract instead of the
+  never-actually-working one.
 - **MCP Resources silently dropped tags/dates/pagination metadata**: `handle_list_resources` and
   `handle_read_resource` computed this metadata and attached it via bare dynamic attributes
   (`resource.tags = ...`) that aren't part of the `Resource`/`TextResourceContents` schema — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   management design, and documented limitations.
 - `LIVE_TESTING.md` extended with a Vault section (`vault_status`, `encrypt_note`, `decrypt_note`,
   verifying encrypted bodies never leak into search results or snippets).
+- `LIVE_TESTING.md`: added a new "MCP Resources & Prompts — Companion Architecture" section, and
+  recorded automated pass results (2026-07-13, 35/35 checks) for both it and the Vault section via
+  the new `simplenote_mcp/scripts/live_test_redesign.py` harness, which drives the real server
+  subprocess over the actual MCP stdio protocol rather than mocking the Simplenote client.
+  `README.md`'s test count corrected (1284 → 1289) and `ROADMAP.md`/`SECURITY.md` wording updated
+  now that Phases 8-10 are merged rather than pending.
 
 ## [1.17.1] - 2026-06-24
 

--- a/LIVE_TESTING.md
+++ b/LIVE_TESTING.md
@@ -1,7 +1,16 @@
-# Live Testing Guide — Simplenote MCP v1.13.0
+# Live Testing Guide — Simplenote MCP v1.17.1
 
 Paste each prompt block into Claude Desktop to verify the tool works.
 Run them in order — later tests depend on notes created earlier.
+
+Sections 19-20 (Vault, Companion Architecture) were additionally verified by an
+automated harness — `simplenote_mcp/scripts/live_test_redesign.py` — that drives
+the real server subprocess over the actual MCP stdio protocol with
+`mcp.ClientSession`, rather than mocking the Simplenote client the way the unit
+suite does. Run it with `SIMPLENOTE_EMAIL`/`SIMPLENOTE_PASSWORD` set:
+`.venv/bin/python simplenote_mcp/scripts/live_test_redesign.py`. It creates and
+trashes its own `LiveTest-Redesign-`-prefixed notes and cleans up after itself,
+including on failure. Last run: 2026-07-13, 35/35 checks passed.
 
 ---
 
@@ -242,6 +251,9 @@ Run them in order — later tests depend on notes created earlier.
 
 ## 19. Vault — Client-Side Encryption
 
+**Automated result (2026-07-13)**: PASS — all sub-checks below confirmed by
+`live_test_redesign.py` against the real Simplenote account.
+
 > Call vault_status. Tell me whether a key is available and which provider it's using.
 
 **Expect**: `key_available` (bool), `key_provider` (`"keyring"` or `"file"`), `encrypted_note_count`. First call may trigger a one-time macOS Keychain approval dialog — approve it.
@@ -276,7 +288,31 @@ Run them in order — later tests depend on notes created earlier.
 
 ---
 
-## 20. Cleanup
+## 20. MCP Resources & Prompts — Companion Architecture
+
+**Automated result (2026-07-13)**: PASS — all sub-checks below confirmed by
+`live_test_redesign.py`, including the exact regression this section exists to
+catch: `read_resource` previously crashed on every real call (see CHANGELOG
+"Fixed" — `'tuple' object has no attribute 'content'`) because the handler
+returned the wrong type for the MCP SDK's `@server.read_resource()` decorator.
+No unit test caught this since they all called the handler function directly,
+bypassing the decorator; only driving the real stdio protocol surfaced it.
+
+> List the available Simplenote resources.
+
+**Expect**: A list of `simplenote://note/<id>` resources. This exercises `handle_list_resources` — each resource's tags and modify/create dates are attached via the MCP `_meta` field (not visible as prose, but the description text should mention the note's tags).
+
+> Read the resource for one of the notes returned above (ask Claude to fetch its content via the resource, not via get_note).
+
+**Expect**: The note's content comes back without error. Before the fix in this section, this call crashed with `'tuple' object has no attribute 'content'` on every invocation — if it errors, that's a live regression, not a flaky test.
+
+> Use the session_handoff_prompt to draft a handoff note for a project called "test-project", with status "wrapping up live testing" and next steps "none".
+
+**Expect**: A prompt response instructing Claude to call `get_or_create_note` and `add_text` with a `Status:`/`Next:`/`Blockers:` formatted body, mentioning "test-project".
+
+---
+
+## 21. Cleanup
 
 > Delete the following test notes (move to Trash):
 > - Live Test Note
@@ -312,5 +348,13 @@ Run them in order — later tests depend on notes created earlier.
 | 16 | `export_notes` | |
 | 17 | `find_and_merge_duplicates` (dry run) | |
 | 18 | `delete_note` + `restore_note` | |
-| 19 | `vault_status`, `encrypt_note`, `decrypt_note`, encrypted search/add_text behavior | |
-| 20 | Cleanup | |
+| 19 | `vault_status`, `encrypt_note`, `decrypt_note`, encrypted search/add_text behavior | ✅ 2026-07-13 (automated) |
+| 20 | `list_resources`/`read_resource` `_meta`, `session_handoff_prompt` | ✅ 2026-07-13 (automated) |
+| 21 | Cleanup | ✅ 2026-07-13 (automated) |
+
+Rows 0-18 test pre-existing Bear-parity tools, unchanged by the companion
+redesign (Phases 8-10) — not re-verified in this pass; see git history for
+when each was last live-tested. Rows 19-21 cover this redesign and were
+verified by `simplenote_mcp/scripts/live_test_redesign.py` (35/35 checks
+passed) rather than manual Claude Desktop prompts — the prompts above remain
+for anyone who wants to confirm the same behavior conversationally.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Irreversible-deletion tools with mandatory safety guards:
 
 - **`permanent_delete_note`**: Permanently destroy a single note; requires `confirm=true`; dry-run preview by default
 - **`empty_trash`**: Permanently delete all trashed notes; defaults to `dry_run=true` (preview); requires `dry_run=false` AND `confirm=true`
-- **1284 tests passing**, 77%+ coverage, zero linting/type errors
+- **1289 tests passing**, 77%+ coverage, zero linting/type errors
 
 See the [CHANGELOG](./CHANGELOG.md) and [ROADMAP.md](ROADMAP.md) for complete details.
 
@@ -84,7 +84,7 @@ See the [CHANGELOG](./CHANGELOG.md) for complete details.
 - 🧩 **MCP Compatible**: Works with Claude Desktop and other MCP clients
 - 🐳 **Docker Ready**: Full containerization with multi-stage builds and security hardening
 - 📊 **Monitoring**: Optional HTTP endpoints for health, readiness, and metrics
-- 🧪 **Robust Testing**: Comprehensive test suite with 1284 tests and continuous integration
+- 🧪 **Robust Testing**: Comprehensive test suite with 1289 tests and continuous integration
 - 🔒 **Security Hardened**: Regular security scanning with Bandit, pip-audit, and dependency checks
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Make Simplenote the best note-taking companion for Claude Desktop: achieve full Bear parity, then surpass it with Simplenote-native capabilities no other note MCP can offer — and become a first-class layer of Claude's working memory, hardened for private data.
 
-**Current version**: v1.17.1 (unreleased Vault additions below) — 30 tools
+**Current version**: v1.17.1 released; Phases 8-10 below (correctness fixes, Vault, companion architecture) merged to `main` and awaiting the next version cut — 30 tools
 **Working checklist**: see [TODO.md](TODO.md)
 **Supersedes**: `docs/ROADMAP.md` (deprecated)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -112,7 +112,7 @@ For detailed information about our automated security monitoring and maintenance
 
 ### Manual Security Testing
 - **Code Review**: Security-focused review on every PR touching credential handling, validation, or (once shipped) the Vault encryption module
-- **Threat Modeling**: Revisited when the trust boundary changes materially (e.g. the Vault feature, planned in [ROADMAP.md](ROADMAP.md))
+- **Threat Modeling**: Revisited when the trust boundary changes materially (e.g. the Vault feature — see [ROADMAP.md](ROADMAP.md) and `docs/security/encryption-design.md`)
 - This is a solo-maintained open-source project — there is no scheduled third-party audit or penetration-testing program. Responsible disclosures are welcome (see Reporting above) and are the primary source of external security review.
 
 ## 📊 Security Monitoring

--- a/TODO.md
+++ b/TODO.md
@@ -244,7 +244,7 @@ Simplenote has no encryption at rest (confirmed via Automattic's own docs — se
 - [x] `[P2]` **Reconcile the two divergent Bandit configs** — `.bandit` and `security.yml`'s `bandit_skip` no longer skip B105; `pyproject.toml [tool.bandit]` never did
 - [x] `[P2]` **`tests/test_vault.py`**: round-trip, tamper detection (flipped byte → raises, never garbage), missing-key behavior, malformed-envelope parsing, key-provider fallback chain
 - [x] `[P2]` **Safety guards** (beyond original scope, added during implementation): `add_text`/`replace_section` refuse on Vault-encrypted notes; `find_and_merge_duplicates` excludes them
-- [ ] `[P2]` **`LIVE_TESTING.md`** entries for the new vault tools (keychain-prompt UX needs a real Claude Desktop session, not just unit tests) — see LIVE_TESTING.md
+- [x] `[P2]` **`LIVE_TESTING.md`** entries for the new vault tools — verified via automated harness (`simplenote_mcp/scripts/live_test_redesign.py`, drives the real server over stdio) rather than a manual Claude Desktop session; 35/35 checks passed 2026-07-13, including catching and fixing a real `read_resource` wire-protocol crash unit tests missed
 
 ## v1.20 — Companion Architecture Layer (Phase 10) ✅
 

--- a/simplenote_mcp/scripts/live_test_redesign.py
+++ b/simplenote_mcp/scripts/live_test_redesign.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Live end-to-end test of the Claude-companion redesign (Phases 8-10).
+
+Spawns the *actual* simplenote-mcp-server subprocess and drives it over the
+real MCP stdio JSON-RPC protocol with mcp.ClientSession — the same path
+Claude Desktop uses — against the live Simplenote account. This exercises
+the full stack (registry, security validation, cache, vault.py, real
+Simplenote API calls, and the actual wire-level serialization) rather than
+calling handler functions in-process.
+
+Covers what unit tests (mocked Simplenote client) cannot prove:
+  - Vault encryption round-trips through the real Simplenote API
+  - Encrypted note bodies never leak into search results over the wire
+  - MCP Resources' `_meta` field actually survives real JSON-RPC serialization
+  - The session-handoff prompt is retrievable via the real protocol
+
+All test notes are prefixed "LiveTest-Redesign-" and trashed at the end,
+including on error (see the `finally` block).
+
+Usage:
+    SIMPLENOTE_WRITE_MODE=true .venv/bin/python simplenote_mcp/scripts/live_test_redesign.py
+"""
+
+import asyncio
+import json
+import os
+import sys
+import time
+from contextlib import AsyncExitStack
+
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+PREFIX = "LiveTest-Redesign-"
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+
+results: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> bool:
+    results.append((name, condition, detail))
+    status = PASS if condition else FAIL
+    print(f"  [{status}] {name}" + (f" — {detail}" if detail and not condition else ""))
+    return condition
+
+
+def tool_json(result) -> dict:
+    return json.loads(result.content[0].text)
+
+
+async def main() -> int:
+    if not os.environ.get("SIMPLENOTE_EMAIL") or not os.environ.get(
+        "SIMPLENOTE_PASSWORD"
+    ):
+        print("SIMPLENOTE_EMAIL / SIMPLENOTE_PASSWORD not set — aborting.")
+        return 1
+
+    env = dict(os.environ)
+    env["SIMPLENOTE_WRITE_MODE"] = "true"
+    env.setdefault("LOG_LEVEL", "WARNING")
+
+    created_note_ids: list[str] = []
+
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "simplenote_mcp"],
+        env=env,
+    )
+
+    async with AsyncExitStack() as stack:
+        read, write = await stack.enter_async_context(stdio_client(server_params))
+        session: ClientSession = await stack.enter_async_context(
+            ClientSession(read, write)
+        )
+        await session.initialize()
+
+        try:
+            # -----------------------------------------------------------
+            print("\n=== Tool registry ===")
+            tools = (await session.list_tools()).tools
+            tool_names = {t.name for t in tools}
+            check("30 tools registered", len(tools) == 30, f"got {len(tools)}")
+            for expected in ("encrypt_note", "decrypt_note", "vault_status"):
+                check(f"{expected} registered", expected in tool_names)
+
+            # -----------------------------------------------------------
+            print("\n=== vault_status (before) ===")
+            status_before = tool_json(await session.call_tool("vault_status", {}))
+            print(
+                f"  key_available={status_before.get('key_available')} "
+                f"provider={status_before.get('key_provider')} "
+                f"encrypted_count={status_before.get('encrypted_note_count')}"
+            )
+            check("vault_status succeeds", status_before.get("success") is True)
+            key_available = bool(status_before.get("key_available"))
+            if not key_available:
+                print(
+                    "  (no Vault key provisioned yet — create_note with encrypt=true "
+                    "will provision one via the OS keychain, may prompt once)"
+                )
+
+            # -----------------------------------------------------------
+            print("\n=== Vault: create_note(encrypt=true) ===")
+            secret_marker = f"live-test-secret-{int(time.time())}"
+            title = f"{PREFIX}Vault {int(time.time())}"
+            create_result = tool_json(
+                await session.call_tool(
+                    "create_note",
+                    {
+                        "content": f"{title}\nvery sensitive body containing {secret_marker}",
+                        "tags": ["live-test"],
+                        "encrypt": True,
+                    },
+                )
+            )
+            note_id = create_result.get("note_id")
+            if note_id:
+                created_note_ids.append(note_id)
+            check(
+                "create_note(encrypt=true) succeeds",
+                create_result.get("success") is True,
+            )
+            check(
+                "response reports encrypted=true",
+                create_result.get("encrypted") is True,
+            )
+            check(
+                "vault-encrypted tag present",
+                "vault-encrypted" in (create_result.get("tags") or []),
+            )
+
+            # -----------------------------------------------------------
+            print("\n=== Vault: get_note decrypts transparently ===")
+            await asyncio.sleep(1)  # let Simplenote settle
+            got = tool_json(await session.call_tool("get_note", {"note_id": note_id}))
+            check("get_note succeeds", got.get("success") is True)
+            check("encrypted=true", got.get("encrypted") is True)
+            check("decryptable=true", got.get("decryptable") is True)
+            check(
+                "decrypted content matches original",
+                secret_marker in (got.get("content") or ""),
+            )
+            # title is truncated to config.title_max_length (default 30 chars)
+            # by tool_handlers.extract_title_from_content — a prefix match is
+            # the correct check, not exact equality.
+            check(
+                "title still readable",
+                bool(got.get("title")) and title.startswith(got.get("title") or "\0"),
+            )
+
+            # -----------------------------------------------------------
+            print("\n=== Vault: encrypted body never leaks into search ===")
+            search_secret = tool_json(
+                await session.call_tool(
+                    "search_notes",
+                    {"query": secret_marker.split("-")[-1] and secret_marker},
+                )
+            )
+            leaked = any(
+                secret_marker in json.dumps(r) for r in search_secret.get("results", [])
+            )
+            check("search for secret body text finds nothing", not leaked)
+
+            search_title = tool_json(
+                await session.call_tool("search_notes", {"query": title})
+            )
+            found_by_title = any(
+                r.get("id") == note_id for r in search_title.get("results", [])
+            )
+            check("search for plaintext title still finds the note", found_by_title)
+            if found_by_title:
+                matched = next(r for r in search_title["results"] if r["id"] == note_id)
+                check(
+                    "search result marks it encrypted, snippet has no ciphertext",
+                    matched.get("encrypted") is True
+                    and "SNVAULT" not in matched.get("snippet", ""),
+                )
+
+            # -----------------------------------------------------------
+            print("\n=== Vault: decrypt_note reverses it ===")
+            decrypted = tool_json(
+                await session.call_tool("decrypt_note", {"note_id": note_id})
+            )
+            check("decrypt_note succeeds", decrypted.get("success") is True)
+            check("encrypted=false after decrypt", decrypted.get("encrypted") is False)
+
+            after_decrypt = tool_json(
+                await session.call_tool("get_note", {"note_id": note_id})
+            )
+            check(
+                "content readable without decryption after decrypt_note",
+                secret_marker in (after_decrypt.get("content") or ""),
+            )
+            check(
+                "encrypted=false on get_note too",
+                after_decrypt.get("encrypted") is False,
+            )
+
+            # -----------------------------------------------------------
+            print(
+                "\n=== Vault: encrypt_note re-encrypts an existing plaintext note ==="
+            )
+            reencrypted = tool_json(
+                await session.call_tool("encrypt_note", {"note_id": note_id})
+            )
+            check("encrypt_note succeeds", reencrypted.get("success") is True)
+            check("encrypted=true again", reencrypted.get("encrypted") is True)
+
+            # -----------------------------------------------------------
+            print("\n=== Vault: add_text refuses on an encrypted note ===")
+            guarded = await session.call_tool(
+                "add_text", {"note_id": note_id, "text": "should be refused"}
+            )
+            guarded_data = tool_json(guarded)
+            check(
+                "add_text refuses with vault_encrypted_note",
+                guarded_data.get("success") is False
+                and guarded_data.get("error", {}).get("subcategory")
+                == "vault_encrypted_note",
+            )
+
+            # -----------------------------------------------------------
+            print("\n=== vault_status (after) ===")
+            status_after = tool_json(await session.call_tool("vault_status", {}))
+            check(
+                "encrypted_note_count increased by at least 1",
+                status_after.get("encrypted_note_count", 0)
+                >= status_before.get("encrypted_note_count", 0) + 1,
+            )
+
+            # -----------------------------------------------------------
+            print("\n=== MCP Resources: _meta carries tags/dates/pagination ===")
+            plain_title = f"{PREFIX}Resource {int(time.time())}"
+            plain_note = tool_json(
+                await session.call_tool(
+                    "create_note",
+                    {
+                        "content": f"{plain_title}\nplain body for resource test",
+                        "tags": ["live-test", "resource-check"],
+                    },
+                )
+            )
+            plain_id = plain_note.get("note_id")
+            if plain_id:
+                created_note_ids.append(plain_id)
+            await asyncio.sleep(1)
+
+            resources = await session.list_resources()
+            check(
+                "list_resources returns at least one resource",
+                len(resources.resources) > 0,
+            )
+            our_resource = next(
+                (
+                    r
+                    for r in resources.resources
+                    if str(r.uri) == f"simplenote://note/{plain_id}"
+                ),
+                None,
+            )
+            check("our note appears in list_resources", our_resource is not None)
+            if our_resource is not None:
+                meta = our_resource.meta or {}
+                check(
+                    "resource._meta carries real tags array",
+                    "resource-check" in (meta.get("tags") or []),
+                )
+                check(
+                    "resource description mentions tags",
+                    "resource-check" in (our_resource.description or ""),
+                )
+
+            first = resources.resources[0] if resources.resources else None
+            check(
+                "first resource carries pagination in _meta",
+                bool(first and (first.meta or {}).get("pagination")),
+            )
+
+            read_result = await session.read_resource(f"simplenote://note/{plain_id}")
+            content0 = read_result.contents[0]
+            check(
+                "read_resource content._meta carries tags",
+                "resource-check" in ((content0.meta or {}).get("tags") or []),
+            )
+
+            # -----------------------------------------------------------
+            print("\n=== MCP Prompts: session_handoff_prompt ===")
+            prompts = (await session.list_prompts()).prompts
+            prompt_names = {p.name for p in prompts}
+            check("3 prompts registered", len(prompts) == 3, f"got {len(prompts)}")
+            check(
+                "session_handoff_prompt registered",
+                "session_handoff_prompt" in prompt_names,
+            )
+
+            handoff = await session.get_prompt(
+                "session_handoff_prompt",
+                {
+                    "project": "live-test-project",
+                    "status": "verifying redesign end-to-end",
+                    "next_steps": "none — this is the verification run",
+                    "blockers": "none",
+                },
+            )
+            combined = " ".join(
+                m.content.text for m in handoff.messages if hasattr(m.content, "text")
+            )
+            check(
+                "prompt references get_or_create_note", "get_or_create_note" in combined
+            )
+            check("prompt references add_text", "add_text" in combined)
+            check("prompt includes project name", "live-test-project" in combined)
+
+        finally:
+            print("\n=== Cleanup: trashing test notes ===")
+            for nid in created_note_ids:
+                try:
+                    del_result = tool_json(
+                        await session.call_tool("delete_note", {"note_id": nid})
+                    )
+                    ok = del_result.get("success") is True
+                    print(f"  [{'ok' if ok else 'FAILED'}] trashed {nid}")
+                except Exception as e:  # noqa: BLE001
+                    print(f"  [FAILED] trashing {nid}: {e}")
+
+    print("\n" + "=" * 60)
+    passed = sum(1 for _, ok, _ in results if ok)
+    total = len(results)
+    print(f"RESULTS: {passed}/{total} checks passed")
+    for name, ok, detail in results:
+        if not ok:
+            print(f"  FAILED: {name}" + (f" ({detail})" if detail else ""))
+    return 0 if passed == total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/simplenote_mcp/server/server.py
+++ b/simplenote_mcp/server/server.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 import time
 from collections import deque
+from collections.abc import Iterable
 from typing import Any, cast
 
 # MCP imports
@@ -18,6 +19,9 @@ import mcp.server.stdio  # type: ignore  # noqa: E402
 import mcp.server.streamable_http  # type: ignore  # noqa: E402
 import mcp.types as types  # type: ignore  # noqa: E402
 from mcp.server import NotificationOptions, Server  # type: ignore  # noqa: E402
+from mcp.server.lowlevel.helper_types import (  # type: ignore  # noqa: E402
+    ReadResourceContents,
+)
 from mcp.server.models import InitializationOptions  # type: ignore  # noqa: E402
 
 # External imports
@@ -754,7 +758,7 @@ async def handle_list_resources(
 
 
 @server.read_resource()  # type: ignore
-async def handle_read_resource(uri: AnyUrl) -> types.ReadResourceResult:
+async def handle_read_resource(uri: AnyUrl) -> Iterable[ReadResourceContents]:
     """Handle the read_resource capability.
 
     Args:
@@ -777,7 +781,6 @@ async def handle_read_resource(uri: AnyUrl) -> types.ReadResourceResult:
         raise format_error("uri", "simplenote://note/[note_id] format")
 
     note_id = uri_str.replace("simplenote://note/", "")
-    note_uri = f"simplenote://note/{note_id}"
 
     try:
         from .cache_utils import get_cache_or_create_minimal
@@ -822,17 +825,23 @@ async def handle_read_resource(uri: AnyUrl) -> types.ReadResourceResult:
         # Tags/dates are attached via the MCP spec's `_meta` extension field —
         # see the matching comment in handle_list_resources for why this
         # replaces the previous non-schema dynamic-attribute approach.
-        text_contents = types.TextResourceContents(
-            text=note_content,
-            uri=cast(Any, note_uri),
-            _meta={
-                "tags": note_tags,
-                "modifydate": note_modifydate,
-                "createdate": note_createdate,
-            },
-        )
-
-        return types.ReadResourceResult(contents=[text_contents])
+        # The @server.read_resource() decorator wraps whatever this function
+        # returns into ReadResourceResult itself — it expects
+        # Iterable[ReadResourceContents], not a pre-built ReadResourceResult
+        # (returning the latter gets misidentified as the Iterable case,
+        # since pydantic BaseModel defines __iter__, and iterating it yields
+        # (field_name, value) tuples instead of resource-content objects).
+        return [
+            ReadResourceContents(
+                content=note_content,
+                mime_type="text/plain",
+                meta={
+                    "tags": note_tags,
+                    "modifydate": note_modifydate,
+                    "createdate": note_createdate,
+                },
+            )
+        ]
 
     except Exception as e:
         if isinstance(e, ServerError):

--- a/tests/test_api_interaction.py
+++ b/tests/test_api_interaction.py
@@ -179,20 +179,19 @@ class TestHandleReadResource:
             }
             mock_cache.get_note.return_value = mock_note
 
-            # Call handler after simulating API response
-            result = await handle_read_resource("simplenote://note/note123")
+            # Call handler after simulating API response.
+            # handle_read_resource returns Iterable[ReadResourceContents] —
+            # the @server.read_resource() decorator wraps this into
+            # ReadResourceResult (and attaches the real request URI) itself.
+            result = list(await handle_read_resource("simplenote://note/note123"))
             assert mock_cache.get_note.call_count == 1  # Ensure it was called once
 
             # Verify results
-            assert isinstance(result, types.ReadResourceResult)
-            # Check the contents field
-            assert len(result.contents) == 1
-            content = result.contents[0]
-            assert isinstance(content, types.TextResourceContents)
-            assert content.text == "Note content"  # Verify correct content is returned
-
-            # Verify URI
-            assert str(content.uri) == "simplenote://note/note123"
+            assert len(result) == 1
+            content = result[0]
+            assert (
+                content.content == "Note content"
+            )  # Verify correct content is returned
 
     async def test_read_resource_cache_miss(self):
         """Test reading a resource not in cache."""
@@ -217,14 +216,12 @@ class TestHandleReadResource:
             mock_get_client.return_value = mock_client
 
             # Call handler
-            result = await handle_read_resource("simplenote://note/note123")
+            result = list(await handle_read_resource("simplenote://note/note123"))
 
             # Verify results
-            assert len(result.contents) == 1
-            content = result.contents[0]
-            assert isinstance(content, types.TextResourceContents)
-            assert content.text == "Note content"  # Verify API response content
-            assert str(content.uri) == "simplenote://note/note123"
+            assert len(result) == 1
+            content = result[0]
+            assert content.content == "Note content"  # Verify API response content
 
             # Verify API was called
             mock_cache.get_note.assert_called_once()

--- a/tests/test_end_to_end_scenarios.py
+++ b/tests/test_end_to_end_scenarios.py
@@ -163,11 +163,11 @@ class TestEndToEndScenarios:
         # Mock get_note for individual note retrieval
         mock_client.get_note.return_value = (created_notes[0], 0)
 
-        note_resource = await handle_read_resource(
-            f"simplenote://note/{created_notes[0]['key']}"
+        note_resource = list(
+            await handle_read_resource(f"simplenote://note/{created_notes[0]['key']}")
         )
-        assert note_resource is not None
-        assert created_notes[0]["content"] in note_resource.contents[0].text
+        assert note_resource
+        assert created_notes[0]["content"] in note_resource[0].content
 
         # Step 6: Update a note (add tags)
         updated_note = created_notes[0].copy()
@@ -503,9 +503,11 @@ class TestEndToEndScenarios:
             note = large_dataset[idx]
             mock_client.get_note.return_value = (note, 0)
 
-            resource = await handle_read_resource(f"simplenote://note/{note['key']}")
-            assert resource is not None
-            assert note["content"] in resource.contents[0].text
+            resource = list(
+                await handle_read_resource(f"simplenote://note/{note['key']}")
+            )
+            assert resource
+            assert note["content"] in resource[0].content
 
         # Test 4: Batch operations on large dataset
         # Update multiple notes

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -6,8 +6,6 @@ from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
-from mcp import types as mcp_types
-from mcp.types import ReadResourceResult
 from pydantic import AnyUrl
 
 from simplenote_mcp.server.cache import NoteCache
@@ -152,20 +150,21 @@ class TestPerformance:
             # Add large note to cache
             setup_performance_cache._notes["large_note"] = large_note
 
-            # Measure read performance from cache
+            # Measure read performance from cache.
+            # handle_read_resource returns Iterable[ReadResourceContents] —
+            # the @server.read_resource() decorator wraps this into
+            # ReadResourceResult itself.
             start_time = time.time()
-            result = cast(
-                ReadResourceResult,
-                await handle_read_resource(AnyUrl("simplenote://note/large_note")),
+            result = list(
+                await handle_read_resource(AnyUrl("simplenote://note/large_note"))
             )
             cache_read_time = time.time() - start_time
             print(f"Reading large note from cache took {cache_read_time:.4f} seconds")
             assert cache_read_time < cache_read_threshold, (
                 "Reading from cache should be reasonably fast"
             )
-            first = result.contents[0]
-            assert isinstance(first, mcp_types.TextResourceContents)
-            assert len(first.text) > 10000
+            first = result[0]
+            assert len(first.content) > 10000
 
             # Simulate API read by removing from cache and setting up mock client
             del setup_performance_cache._notes["large_note"]

--- a/tests/test_server_advanced.py
+++ b/tests/test_server_advanced.py
@@ -226,18 +226,22 @@ class TestMCPProtocolHandlers:
         mock_cache.get_note.return_value = mock_note
 
         with patch("simplenote_mcp.server.server.note_cache", mock_cache):
-            result = await handle_read_resource("simplenote://note/test123")
+            # handle_read_resource returns Iterable[ReadResourceContents] —
+            # the @server.read_resource() decorator wraps this into
+            # ReadResourceResult itself. A pre-built ReadResourceResult would
+            # be silently misidentified as that Iterable (pydantic BaseModel
+            # defines __iter__), breaking the real wire protocol.
+            result = list(await handle_read_resource("simplenote://note/test123"))
 
-        assert isinstance(result, types.ReadResourceResult)
-        assert len(result.contents) == 1
+        assert len(result) == 1
 
         # Verify content is returned (format may vary)
-        assert len(result.contents[0].text) > 0
-        assert "Test note content with metadata" in result.contents[0].text
+        assert len(result[0].content) > 0
+        assert "Test note content with metadata" in result[0].content
 
         # Tags/dates must be attached via the schema's `_meta` field, not
         # bare dynamic attributes (regression test for the metadata-loss fix).
-        meta = result.contents[0].meta
+        meta = result[0].meta
         assert meta["tags"] == ["important", "work"]
         assert meta["createdate"] == "2023-01-01T10:00:00Z"
         assert meta["modifydate"] == "2023-01-02T15:30:00Z"

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -520,7 +520,11 @@ class TestHandleReadResource:
         import simplenote_mcp.server.server as srv
 
         note_id = "abc123"
-        fake_note = {"key": note_id, "content": "cached content", "tags": []}
+        fake_note = {
+            "key": note_id,
+            "content": "cached content",
+            "tags": ["work"],
+        }
 
         mock_cache = MagicMock()
         mock_cache.is_initialized = True
@@ -531,11 +535,21 @@ class TestHandleReadResource:
             return_value=mock_cache,
         ):
             uri = AnyUrl(f"simplenote://note/{note_id}")
-            result = await srv.handle_read_resource(uri)
+            result = list(await srv.handle_read_resource(uri))
 
-        assert isinstance(result, types.ReadResourceResult)
-        assert len(result.contents) == 1
-        assert result.contents[0].text == "cached content"
+        # handle_read_resource must return Iterable[ReadResourceContents] —
+        # the @server.read_resource() decorator wraps this into
+        # ReadResourceResult itself. Returning a pre-built ReadResourceResult
+        # here would be silently misinterpreted as that Iterable (pydantic
+        # BaseModel defines __iter__), yielding (field_name, value) tuples
+        # instead of resource contents and crashing the real wire protocol.
+        assert len(result) == 1
+        assert result[0].content == "cached content"
+        assert result[0].meta == {
+            "tags": ["work"],
+            "modifydate": "",
+            "createdate": "",
+        }
 
     @pytest.mark.asyncio
     async def test_note_not_in_cache_fetched_from_api(self):
@@ -566,10 +580,9 @@ class TestHandleReadResource:
             ),
         ):
             uri = AnyUrl(f"simplenote://note/{note_id}")
-            result = await srv.handle_read_resource(uri)
+            result = list(await srv.handle_read_resource(uri))
 
-        assert isinstance(result, types.ReadResourceResult)
-        assert result.contents[0].text == "api content"
+        assert result[0].content == "api content"
 
     @pytest.mark.asyncio
     async def test_api_failure_raises_resource_not_found(self):


### PR DESCRIPTION
## Description
Live-testing the companion redesign (Phases 8-10, PRs #694/#695/#696) against the real Simplenote account over the actual MCP stdio protocol surfaced a crash that the mocked unit-test suite never exercised: `read_resource` failed on **every** call with `'tuple' object has no attribute 'content'`.

**Root cause**: `handle_read_resource` returned a pre-built `types.ReadResourceResult`, but the MCP SDK's `@server.read_resource()` decorator expects the handler to return `str | bytes | Iterable[ReadResourceContents]` and wraps that into a `ReadResourceResult` itself. Because pydantic `BaseModel` defines `__iter__` (for `.dict()`-style conversion), the decorator's `isinstance(result, Iterable)` check matched the returned `ReadResourceResult` too, then iterated it expecting resource-content objects and got `(field_name, value)` tuples instead.

Every existing unit test called `handle_read_resource` directly, bypassing the `@server.read_resource()` decorator entirely, so none of them exercised the real dispatch path — only a live client driving the actual wire protocol caught this.

**Fix**: return `list[ReadResourceContents]` as the SDK actually expects. Five unit tests updated to assert the corrected contract instead of the never-actually-working one.

Also includes the live-test harness itself (`simplenote_mcp/scripts/live_test_redesign.py`) that found this — drives the real server subprocess over stdio with `mcp.ClientSession`, the same path Claude Desktop uses — plus a fix to its own title-truncation assertion (`config.title_max_length` truncates at 30 chars by design; the test asserted exact equality against a longer title), and documentation updates recording the live-test results.

## Related Issue
None — found via live testing, not a filed issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing
- [x] Full offline suite: `SIMPLENOTE_OFFLINE_MODE=true pytest tests/ -q --timeout=30` — 1289 passed, 8 skipped
- [x] `ruff check .` / `ruff format .` / `mypy simplenote_mcp` / `bandit -c pyproject.toml -r simplenote_mcp` — all clean
- [x] Live end-to-end run against the real Simplenote account via `simplenote_mcp/scripts/live_test_redesign.py` — 35/35 checks passed, including the `read_resource` call that previously crashed on every invocation

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (CHANGELOG.md, TODO.md, LIVE_TESTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix the MCP read_resource handler’s return contract to work correctly over the real wire protocol and add a live end-to-end harness that validates the companion redesign against a real Simplenote account.

Bug Fixes:
- Correct read_resource to return iterable resource contents as expected by the MCP SDK decorator, preventing crashes when invoked over the real MCP stdio protocol.
- Update tests to assert the corrected read_resource contract and metadata behavior, ensuring cache, API, and performance paths exercise the real dispatch semantics.

Enhancements:
- Add a live stdio-based MCP test harness that drives the real server subprocess and verifies Vault, resources metadata, and companion prompts end-to-end.
- Record automated live-testing results for Vault and companion architecture sections in LIVE_TESTING.md and clarify roadmap/security wording around the Vault feature.
- Refresh README test counts to reflect the expanded suite and mark roadmap phases 8–10 as merged and awaiting release, with corresponding TODO status updates.

Documentation:
- Extend LIVE_TESTING.md with automated verification notes for Vault and companion architecture resources/prompts, including the regression that live testing caught.
- Update CHANGELOG, README, ROADMAP, SECURITY, and TODO documentation to describe the read_resource protocol fix, new live testing harness, and current test coverage.

Tests:
- Adjust existing unit, integration, and performance tests to treat handle_read_resource as returning iterable contents, and add expectations around resource metadata and Vault behaviors exercised via the live harness.