### PR TITLE
fix: resolve 2026-07-13 security & code quality audit findings

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.branch-check.outputs.exists == 'true'
-        uses: actions/checkout@v7
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
         with:
           ref: ${{ steps.branch-info.outputs.target_branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set up Python
         if: steps.branch-check.outputs.exists == 'true'
-        uses: actions/setup-python@v6
+        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -175,7 +175,7 @@ jobs:
       - name: Find associated PRs
         if: steps.git-check.outputs.changes_made == 'true'
         id: find-pr
-        uses: actions/github-script@v9
+        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
         with:
           script: |
             const branch = '${{ steps.branch-info.outputs.target_branch }}';
@@ -195,7 +195,7 @@ jobs:
 
       - name: Comment on PR about auto-fixes
         if: steps.git-check.outputs.changes_made == 'true' && steps.find-pr.outputs.result
-        uses: actions/github-script@v9
+        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
         with:
           script: |
             const prNumber = ${{ steps.find-pr.outputs.result }};

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Check if PR is ready for merge
         id: check
-        uses: actions/github-script@v9
+        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -111,7 +111,7 @@ jobs:
 
       - name: Enable auto-merge
         if: steps.check.outputs.result == 'true'
-        uses: actions/github-script@v9
+        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: 25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/claude-dependabot-merge.yml
+++ b/.github/workflows/claude-dependabot-merge.yml
@@ -50,7 +50,13 @@ jobs:
       issues: read
       checks: read
       statuses: read
-    secrets: inherit
+    # Explicit mapping instead of `secrets: inherit` — the reusable
+    # workflow's own workflow_call interface (docdyhr/.github) declares
+    # exactly these two; inherit would also hand it DOCKER_TOKEN,
+    # CODECOV_TOKEN, and everything else this repo happens to have.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       merge_mode: ${{ github.event.inputs.merge_mode || 'dry-run' }}
       scope: ${{ github.event.inputs.scope || 'all' }}

--- a/.github/workflows/claude-status-check.yml
+++ b/.github/workflows/claude-status-check.yml
@@ -45,7 +45,11 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    secrets: inherit
+    # Explicit mapping instead of `secrets: inherit` — see
+    # claude-dependabot-merge.yml for why.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       create_issue: ${{ github.event.inputs.create_issue == 'true' }}
       max_budget_usd: ${{ github.event.inputs.max_budget_usd || '0.25' }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,10 +14,9 @@ jobs:
     name: Dependency Review
     steps:
       - name: "📥 Checkout Repository"
-        uses: actions/checkout@v7
-
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
       - name: "🔍 Dependency Review"
-        uses: actions/dependency-review-action@v5
+        uses: a1d282b36b6f3519aa1f3fc636f609c47dddb294 # actions/dependency-review-action@v5
         with:
           # Fail the workflow if vulnerabilities are found
           fail-on-severity: moderate

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -95,7 +95,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload documentation artifacts
-        uses: actions/upload-pages-artifact@v5
+        uses: fc324d3547104276b827a68afc52ff2a11cc49c9 # actions/upload-pages-artifact@v5
         with:
           path: ./site
 
@@ -121,7 +121,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # actions/deploy-pages@v5
         continue-on-error: true
 
       - name: Handle deployment failure
@@ -145,10 +145,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
-
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
       - name: Download documentation artifacts
-        uses: actions/download-artifact@v8
+        uses: 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           name: github-pages
           path: ./site
@@ -159,7 +158,7 @@ jobs:
           tar -xf artifact.tar
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: e7477775783ea5526144ba13e8db5eec57747ce8 # lycheeverse/lychee-action@v2
         with:
           args: --verbose --no-progress --config .lycheerc.toml './site/**/*.html' --exclude-mail
           fail: false  # Don't fail workflow on link issues, just report them
@@ -171,7 +170,7 @@ jobs:
 
       - name: Upload link check report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: link-check-report
           path: lychee-report.md

--- a/.github/workflows/evaluation-quality-gate.yml
+++ b/.github/workflows/evaluation-quality-gate.yml
@@ -52,16 +52,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
-
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           # Note: npm cache disabled - package-lock.json may not exist
@@ -284,7 +283,7 @@ jobs:
 
       - name: Upload evaluation artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: evaluation-results-${{ steps.eval-suite.outputs.suite }}
           path: |
@@ -399,7 +398,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.report.outputs.report_created == 'true'
-        uses: actions/github-script@v9
+        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -444,7 +443,7 @@ jobs:
 
       - name: Create check run
         if: always()
-        uses: actions/github-script@v9
+        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
         with:
           script: |
             const passRate = '${{ needs.run-evaluations.outputs.pass-rate || '0' }}';
@@ -490,7 +489,7 @@ jobs:
 
       - name: Upload quality gate report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: quality-gate-report
           path: quality-gate-report.md

--- a/.github/workflows/mcp-evaluations.yml
+++ b/.github/workflows/mcp-evaluations.yml
@@ -33,16 +33,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
-
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"
 
       - name: Setup Node.js for mcp-evals
-        uses: actions/setup-node@v6
+        uses: 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6
         with:
           node-version: "20"
           # Note: npm cache disabled - package-lock.json may not exist on scheduled runs
@@ -81,7 +80,7 @@ jobs:
 
       - name: Run smoke tests
         if: steps.check-openai.outputs.has-openai-key == 'true'
-        uses: mclenhard/mcp-evals@v1.0.14
+        uses: 614087def55f3b68258580b05f0ae3a7d55207b4 # mclenhard/mcp-evals@v1.0.14
         timeout-minutes: 10
         with:
           evals_path: "evals/smoke-tests.yaml"
@@ -117,7 +116,7 @@ jobs:
 
       - name: Run comprehensive evaluations
         if: (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'comprehensive-eval')) && steps.check-openai.outputs.has-openai-key == 'true'
-        uses: mclenhard/mcp-evals@v1.0.14
+        uses: 614087def55f3b68258580b05f0ae3a7d55207b4 # mclenhard/mcp-evals@v1.0.14
         with:
           evals_path: "evals/comprehensive-evals.yaml"
           server_path: "simplenote_mcp_server.py"
@@ -127,7 +126,7 @@ jobs:
 
       - name: Run basic evaluations
         if: github.event_name != 'workflow_dispatch' && steps.check-openai.outputs.has-openai-key == 'true'
-        uses: mclenhard/mcp-evals@v1.0.14
+        uses: 614087def55f3b68258580b05f0ae3a7d55207b4 # mclenhard/mcp-evals@v1.0.14
         with:
           evals_path: "evals/simplenote-evals.yaml"
           server_path: "simplenote_mcp_server.py"
@@ -158,7 +157,7 @@ jobs:
 
       - name: Upload evaluation summary
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: evaluation-summary
           path: evaluation-summary.md
@@ -175,12 +174,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
         with:
           fetch-depth: 0 # Need full history for diff
 
       - name: Setup Node.js for mcp-evals
-        uses: actions/setup-node@v6
+        uses: 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6
         with:
           node-version: "20"
           # Note: npm cache disabled - package-lock.json may not exist
@@ -253,7 +252,7 @@ jobs:
 
       - name: Comment on PR with evaluation info
         if: steps.eval-changes.outputs.eval_files_changed == 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
         continue-on-error: true
         with:
           script: |

--- a/.github/workflows/monitoring-consolidated.yml
+++ b/.github/workflows/monitoring-consolidated.yml
@@ -56,10 +56,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
-
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -85,7 +84,7 @@ jobs:
 
       - name: Upload security reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: security-reports-${{ github.run_id }}
           path: |
@@ -114,10 +113,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
-
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -166,8 +164,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
-
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
       - name: Validate README badges
         run: |
           echo "Validating badges in README.md..."

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,11 +15,11 @@ jobs:
     permissions:
       id-token: write  # required for OIDC Trusted Publishing
     steps:
-      - uses: actions/checkout@v7
+      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag }}
 
-      - uses: actions/setup-python@v6
+      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -29,6 +29,6 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: cef221092ed1bacb1cc03d23a2d87d1d172e277b # pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -155,7 +155,7 @@ jobs:
       - name: Create GitHub Release
         id: create_release
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: softprops/action-gh-release@v3
+        uses: c12583777ecdfd3be55c69cf75464299dc01057e # softprops/action-gh-release@v3
         with:
           name: "v${{ steps.bump_version.outputs.new_version }}"
           tag_name: "v${{ steps.bump_version.outputs.new_version }}"
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload changelog artifact
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: changelog-${{ steps.bump_version.outputs.new_version }}
           path: changelog.md
@@ -187,12 +187,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
         with:
           ref: v${{ needs.prepare-release.outputs.new_version }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -375,7 +375,7 @@ jobs:
           echo "✅ SBOM and vulnerability report generation completed"
 
       - name: Upload SBOM and vulnerability artifacts
-        uses: actions/upload-artifact@v7
+        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: security-reports-${{ needs.prepare-release.outputs.new_version }}
           path: |
@@ -387,7 +387,7 @@ jobs:
 
       - name: Publish to PyPI
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: cef221092ed1bacb1cc03d23a2d87d1d172e277b # pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: false
 
@@ -405,7 +405,7 @@ jobs:
 
     steps:
       - name: Download security artifacts
-        uses: actions/download-artifact@v8
+        uses: 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           name: security-reports-${{ needs.prepare-release.outputs.new_version }}
           path: security-reports/
@@ -416,7 +416,7 @@ jobs:
           ls -la security-reports/
           
       - name: Attach SBOM and vulnerability reports to release
-        uses: softprops/action-gh-release@v3
+        uses: c12583777ecdfd3be55c69cf75464299dc01057e # softprops/action-gh-release@v3
         with:
           tag_name: "v${{ needs.prepare-release.outputs.new_version }}"
           files: |

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -40,13 +40,13 @@ jobs:
             echo "Warning: Large file detected: $file ($(du -h "$file" | cut -f1))"
           done
 
-      - uses: actions/setup-python@v6
+      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
 
       - name: Cache dependencies
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6
         id: cache
         with:
           path: |
@@ -78,15 +78,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-python@v6
+      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
 
       - name: Restore dependencies
-        uses: actions/cache@v6
+        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6
         with:
           path: |
             ~/.cache/pip
@@ -126,7 +125,7 @@ jobs:
           pytest simplenote_mcp/tests/ --randomly-seed=${{ github.run_id }} --no-cov
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v7
+        uses: a99c28d3f0da835de33ff2feb2e15691c7b9641f # codecov/codecov-action@v7
         with:
           file: ./coverage.xml
           fail_ci_if_error: true
@@ -137,9 +136,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-python@v6
+      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -170,22 +168,21 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v7
-
+      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: 96fe6ef7f33517b61c61be40b68a1882f3264fb8 # docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # docker/setup-buildx-action@v4
         with:
           version: latest
           platforms: linux/amd64,linux/arm64
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: af1e73f918a031802d376d3c8bbc3fe56130a9b0 # docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -193,7 +190,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: af1e73f918a031802d376d3c8bbc3fe56130a9b0 # docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -201,7 +198,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: dc802804100637a589fabce1cb79ff13a1411302 # docker/metadata-action@v6
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -218,7 +215,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: 53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -231,7 +228,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           format: "sarif"
@@ -242,14 +239,14 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: github.event_name != 'pull_request'
-        uses: github/codeql-action/upload-sarif@v4
+        uses: 1ad29ea4a422cce9a242a9fae469541dcd08addc # github/codeql-action/upload-sarif@v4
         with:
           sarif_file: "trivy-results.sarif"
           category: "trivy-container-scan"
 
       - name: Update Docker Hub repository description
         if: github.event_name != 'pull_request'
-        uses: peter-evans/dockerhub-description@v5
+        uses: 1b9a80c056b620d92cedb9d9b5a223409c68ddfa # peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -262,9 +259,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-python@v6
+      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -110,6 +110,21 @@ jobs:
         run: |
           python scripts/quality/check_coverage.py --threshold 75.0
 
+      - name: Run legacy test suite (separate process — do not merge into tests/)
+        env:
+          SIMPLENOTE_EMAIL: test@example.com
+          SIMPLENOTE_PASSWORD: test-password
+        run: |
+          # simplenote_mcp/tests/ and tests/ both exercise process-global
+          # singletons (metrics collector, security validator). Each tree
+          # resets them for its own tests via an autouse conftest fixture,
+          # but that only protects tests within the same tree — collecting
+          # both into one `pytest` invocation (one process) lets tests from
+          # one tree corrupt the other's state. Keeping this a fully
+          # separate `pytest` process (own testpaths, own working memory)
+          # sidesteps that; do not add this directory to testpaths above.
+          pytest simplenote_mcp/tests/ --randomly-seed=${{ github.run_id }} --no-cov
+
       - name: Upload coverage
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -80,7 +80,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: 5f6978faf089d4d20b00c7766989d076bb2fc7f1 # peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-package-lock.json
 .npm/
 
 # MCP Evals outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no-opped, and only the tag index was ever built for notes from the initial background load.
   `_populate_cache_direct()` now builds the full tag/title/word index via the same
   `_build_all_indexes()` used by `initialize()`.
+- **MCP tool errors were indistinguishable from success at the protocol level**: `handle_call_tool`
+  and the shared handler error-formatting path (`ToolHandlerBase._format_error_response`) returned
+  plain `TextContent`, which the MCP SDK's `call_tool()` decorator normalizes to `isError=False`
+  regardless of the actual outcome — a client had to parse the JSON body to notice a tool call had
+  failed. Both now return `CallToolResult(isError=True)`, which the SDK honors natively. Failed
+  writes no longer consume the write budget.
+- **Date-filtered search crashed on every ISO date and rejected every natural-language one**:
+  security validation converted `from_date`/`to_date` to a `datetime` object before the search
+  handler's own parser (which expects a string) ran on it, and only ISO-format strings survived
+  validation to begin with. Also fixed `parse_natural_date` itself: it didn't actually handle the
+  underscored aliases (`3_days_ago`, `last_monday`) the tool schema advertises as examples — only
+  spaced variants (`3 days ago`) worked.
+- **Docker/Helm deployments never actually served anything**: `MCP_TRANSPORT` defaults to `stdio`,
+  but `docker-compose.yml`, `docker-compose.dev.yml`, and the Helm chart's `configMap` all exposed
+  port 8000 without ever setting it to `http` — the documented container path was unreachable.
+  HEALTHCHECK/liveness/readiness probes only checked that the package imports, not that the
+  process was serving requests; replaced with real checks against `/health`/`/ready`. That
+  surfaced a real, separate bug in the health endpoint itself while testing the fix in a live
+  container: `/health` returned 503 for a merely "degraded" status (e.g. a low cache hit rate,
+  completely normal right after startup or during a quiet period), not just a genuinely
+  "unhealthy" one — wired to a Kubernetes `livenessProbe` (as this same change does), that would
+  have caused restart loops on any lightly used server. Only genuine `unhealthy` checks fail the
+  probe now.
+- Restored `simplenote_mcp/tests/` (112 tests) to CI — deliberately as a separate pytest process
+  from `tests/`, not merged into `testpaths`: both trees mutate the same process-global singletons
+  (metrics collector, security validator), and each only resets them for its own tests, so
+  collecting both into one `pytest` invocation let one tree corrupt the other's state (confirmed
+  empirically). Fixed the bug behind most of the individual test failures in one place: the
+  offline-mode mock Simplenote client returned static, contentless notes instead of storing and
+  echoing back what was actually written, so nothing that round-tripped a note through create →
+  retrieve/update could pass.
+- `Config.validate()` existed and was comprehensive but was never called on any startup path —
+  invalid configuration (a bad `MCP_TRANSPORT` value, missing credentials outside offline mode,
+  etc.) now fails fast at startup with a clear message instead of surfacing later, less clearly,
+  during client/cache initialization.
 
 ### Changed
 - Declared JSON schema for `tags` unified to `array<string>` across all tag-accepting tools
@@ -96,6 +131,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SecurityValidator.validate_arguments()`'s tag count/length/character validation now applies
   to all 8 tag-accepting tools (`create_note`, `update_note`, `add_tags`, `remove_tags`,
   `replace_tags`, `get_or_create_note`, `bulk_tag`), not just 3.
+- **Docker/Helm deployments now require `MCP_HTTP_AUTH_TOKEN`** to actually serve MCP requests
+  (see Security below) — `docker-compose.yml`/`.dev.yml` and the Helm chart set
+  `MCP_TRANSPORT=http`/`ENABLE_HTTP_ENDPOINT=true` and expect this to be provided; deployments
+  relying on the old (non-functional) defaults need `MCP_HTTP_AUTH_TOKEN` set before upgrading.
+- Production Docker image now installs only runtime dependencies
+  (`requirements-runtime-lock.txt`, 54 packages, resolved from a clean `pip install .` with no
+  extras) instead of the `.[all]` extra, which pulled bandit/mypy/ruff/pytest/pre-commit/twine and
+  more into what ships. Verified via `pip list` in the built image.
+- `setup.py`'s version and dependencies synced to match `pyproject.toml` (was reporting `1.12.0`
+  with a 3-package list against the real `1.17.1`/10-package one); now checked by
+  `check_version_consistency.py` alongside the other four version sources.
 
 ### Dependencies
 - `cryptography` and `keyring` promoted from transitive (dev/publish tooling only) to direct
@@ -107,6 +153,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bandit_skip` no longer skip B105 (hardcoded-password-string) — `pyproject.toml [tool.bandit]`
   never did. Kept active so key-handling code (`vault.py`) is guarded against accidentally
   hardcoded secrets.
+- **MCP HTTP transport had no authentication or DNS-rebinding protection**: `MCP_TRANSPORT=http`
+  now refuses to start on any non-loopback `MCP_HTTP_HOST` unless `MCP_HTTP_AUTH_TOKEN` (a bearer
+  token, checked via constant-time comparison) is set. Loopback binds remain token-free, matching
+  stdio's local-process trust level. New `MCP_HTTP_ALLOWED_HOSTS`/`MCP_HTTP_ALLOWED_ORIGINS` enable
+  DNS-rebinding protection for non-loopback binds. See README's Security section.
+- **Tool call arguments — including full note content and search queries — were logged in full at
+  INFO level** on every call, before Vault encryption ever touched them. INFO now logs only the
+  tool name and argument count; a sanitized/truncated form (matching the redaction already used
+  elsewhere for security-event logging) is available at DEBUG.
+- **A corrupted Vault key could be silently overwritten with a brand-new one**: the key-file/
+  keychain read helpers couldn't distinguish "not yet provisioned" from "exists but is unreadable,
+  malformed, or the wrong length," so `get_or_create_vault_key()` would generate and persist a
+  replacement key over a merely-corrupt existing one — permanently orphaning any notes already
+  encrypted with the original. Now raises a distinct `VaultKeyCorruptedError` and never
+  auto-replaces an existing key; `vault_status` reports the corruption in its response instead of
+  crashing (it's the tool a user would run specifically to diagnose this).
+- **Rate limiting and the write budget were effectively global, not per-client**: an outer
+  `@rate_limit(60, 60)` decorator on `handle_call_tool` was structurally dead code — it wrapped a
+  function reference the MCP SDK's actual request-dispatch path never calls through — and the live
+  rate limiter always resolved every caller to the same `"default"` identifier, as did the write
+  budget. Both now key off a real per-client identity: source IP for HTTP-transport callers, a
+  fixed identifier for stdio (correct there, not a gap — one process is genuinely one client).
+- Pinned all 25 third-party GitHub Actions (~76 call sites across 13 workflow files) from mutable
+  version tags to immutable commit SHAs. `secrets: inherit` on the two Claude-powered
+  reusable-workflow callers (Dependabot auto-merge, status check) narrowed to the specific two
+  secrets they actually consume, confirmed against the reusable workflows' own declared interface,
+  instead of implicitly handing them every secret this repo has configured.
 
 ### Docs
 - `SECURITY.md` corrected: removed false "encryption at rest" and "memory protection" claims

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,22 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 COPY pyproject.toml ./
 COPY setup.py ./
 COPY VERSION ./
+COPY requirements-runtime-lock.txt ./
 
-# Install build dependencies first (setuptools>=78.1.1 for jaraco.context CVE fix)
-RUN pip install --no-cache-dir --upgrade pip "setuptools>=78.1.1" "wheel>=0.46.2" build
+# Install build dependencies first (setuptools>=78.1.1 for jaraco.context CVE fix).
+# The standalone `build` package isn't needed: `pip install .` on a PEP
+# 517 project builds via its own isolated build environment.
+RUN pip install --no-cache-dir --upgrade pip "setuptools>=78.1.1" "wheel>=0.46.2"
 
 # Copy source code
 COPY simplenote_mcp/ simplenote_mcp/
 
-# Build and install the package properly
-RUN pip install --no-cache-dir .[all]
+# Install pinned runtime dependencies, then the package itself without
+# re-resolving deps. Deliberately NOT `.[all]` — that extra pulls in
+# ruff/mypy/bandit/pytest/pre-commit/twine/build and more, none of which
+# belong in a production image (see requirements-runtime-lock.txt).
+RUN pip install --no-cache-dir -r requirements-runtime-lock.txt \
+    && pip install --no-cache-dir --no-deps .
 
 # Production stage
 ARG PYTHON_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,12 @@ ENV HOME=/home/mcp
 # Expose port for HTTP transport (default MCP port)
 EXPOSE 8000
 
-# Add health check that actually tests the module import
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import simplenote_mcp.server; print('Health check passed')" || exit 1
+# Real health check against the monitoring server (requires
+# ENABLE_HTTP_ENDPOINT=true, HTTP_PORT=8080 — see README) — an import-only
+# check proves the package is installed, not that the process is serving
+# anything. No curl in this image, so a Python one-liner.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD python -c "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=5).status == 200 else 1)"
 
 # Add metadata labels
 LABEL org.opencontainers.image.created="${BUILDTIME}"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
-.PHONY: test test-fast
+.PHONY: test test-fast test-legacy
 
 test:
 	SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest -q
 
 test-fast:
 	SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest tests/ -x -q --timeout=30
+
+# simplenote_mcp/tests/ — kept as a separate pytest process deliberately:
+# both trees exercise process-global singletons (metrics collector,
+# security validator), and each resets them only for its own tests, so
+# merging them into one pytest invocation lets one tree corrupt the
+# other's state. See unified-ci.yml's "Run legacy test suite" step.
+test-legacy:
+	SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest simplenote_mcp/tests/ -q --timeout=30 --no-cov

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Irreversible-deletion tools with mandatory safety guards:
 
 - **`permanent_delete_note`**: Permanently destroy a single note; requires `confirm=true`; dry-run preview by default
 - **`empty_trash`**: Permanently delete all trashed notes; defaults to `dry_run=true` (preview); requires `dry_run=false` AND `confirm=true`
-- **1289 tests passing**, 77%+ coverage, zero linting/type errors
+- **1334 tests passing**, 79%+ coverage, zero linting/type errors
 
 See the [CHANGELOG](./CHANGELOG.md) and [ROADMAP.md](ROADMAP.md) for complete details.
 
@@ -84,7 +84,7 @@ See the [CHANGELOG](./CHANGELOG.md) for complete details.
 - 🧩 **MCP Compatible**: Works with Claude Desktop and other MCP clients
 - 🐳 **Docker Ready**: Full containerization with multi-stage builds and security hardening
 - 📊 **Monitoring**: Optional HTTP endpoints for health, readiness, and metrics
-- 🧪 **Robust Testing**: Comprehensive test suite with 1289 tests and continuous integration
+- 🧪 **Robust Testing**: Comprehensive test suite with 1334 tests and continuous integration
 - 🔒 **Security Hardened**: Regular security scanning with Bandit, pip-audit, and dependency checks
 
 ---

--- a/README.md
+++ b/README.md
@@ -106,14 +106,24 @@ docker run -d \
   --name simplenote-mcp \
   -e SIMPLENOTE_EMAIL=your.email@example.com \
   -e SIMPLENOTE_PASSWORD=your-password \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HTTP_HOST=0.0.0.0 \
+  -e MCP_HTTP_AUTH_TOKEN=your-random-secret-token \
   -p 8000:8000 \
   docdyhr/simplenote-mcp-server:latest
 ```
 
-**Docker Health Checks:** The container includes built-in health monitoring endpoints:
-- Health: `http://localhost:8000/health`
-- Readiness: `http://localhost:8000/ready`  
-- Metrics: `http://localhost:8000/metrics` (Prometheus format)
+`MCP_HTTP_AUTH_TOKEN` is required whenever `MCP_HTTP_HOST` is anything other
+than `127.0.0.1`/`localhost` — the server refuses to start otherwise (see the
+Security section below). Without `MCP_TRANSPORT=http`, the server runs over
+stdio by default and nothing listens on the published port at all.
+
+**Docker Health Checks:** health monitoring is a *separate* HTTP endpoint
+from the MCP protocol port above — it's off by default and must be enabled
+explicitly with `-e ENABLE_HTTP_ENDPOINT=true -p 8080:8080`:
+- Health: `http://localhost:8080/health`
+- Readiness: `http://localhost:8080/ready`
+- Metrics: `http://localhost:8080/metrics` (Prometheus format)
 
 Or use Docker Compose:
 
@@ -177,14 +187,17 @@ The easiest way to use the server is with our pre-built Docker images:
 # Pull the latest image
 docker pull docdyhr/simplenote-mcp-server:latest
 
-# Run with Docker
+# Run with Docker (see Quick Start above for the required MCP_HTTP_* env vars)
 docker run -d \
   -e SIMPLENOTE_EMAIL=your.email@example.com \
   -e SIMPLENOTE_PASSWORD=your-password \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HTTP_HOST=0.0.0.0 \
+  -e MCP_HTTP_AUTH_TOKEN=your-random-secret-token \
   -p 8000:8000 \
   docdyhr/simplenote-mcp-server:latest
 
-# Or use Docker Compose
+# Or use Docker Compose (set MCP_HTTP_AUTH_TOKEN in your environment/.env first)
 docker-compose up -d
 ```
 
@@ -205,6 +218,9 @@ docker build -t simplenote-mcp-server .
 docker run -d \
   -e SIMPLENOTE_EMAIL=your.email@example.com \
   -e SIMPLENOTE_PASSWORD=your-password \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HTTP_HOST=0.0.0.0 \
+  -e MCP_HTTP_AUTH_TOKEN=your-random-secret-token \
   -p 8000:8000 \
   simplenote-mcp-server
 ```
@@ -294,6 +310,13 @@ resources:
 | `CACHE_MAX_SIZE`        | No       | 10000   | Max notes held in memory — set ≥ your total note count   |
 | `LOG_LEVEL`             | No       | INFO    | Logging level (DEBUG, INFO, WARNING, ERROR)              |
 | `SIMPLENOTE_OFFLINE_MODE` | No     | false   | Skip API calls; used for testing without credentials     |
+| `MCP_TRANSPORT`         | No       | stdio   | `stdio` or `http` — the MCP protocol transport            |
+| `MCP_HTTP_HOST`         | No       | 127.0.0.1 | Bind host when `MCP_TRANSPORT=http`                     |
+| `MCP_HTTP_AUTH_TOKEN`   | Conditional | -    | Bearer token; **required** if `MCP_HTTP_HOST` is non-loopback |
+| `MCP_HTTP_ALLOWED_HOSTS` | No      | -       | Comma-separated allowlist for DNS-rebinding protection    |
+| `MCP_HTTP_ALLOWED_ORIGINS` | No   | -       | Comma-separated Origin allowlist (used with the above)    |
+| `ENABLE_HTTP_ENDPOINT`  | No       | false   | Enable the separate `/health`, `/ready`, `/metrics` server |
+| `HTTP_PORT`             | No       | 8080    | Port for the monitoring endpoint above                    |
 
 ### Claude Desktop Integration
 
@@ -528,6 +551,16 @@ mypy simplenote_mcp
 - **Security-hardened containers** with non-root users
 - **Read-only filesystem** in production containers
 - **Resource limits** to prevent abuse
+- **MCP HTTP transport is fail-closed by default**: `MCP_TRANSPORT=http`
+  refuses to start on any non-loopback `MCP_HTTP_HOST` unless
+  `MCP_HTTP_AUTH_TOKEN` is set (a shared bearer secret, checked via
+  constant-time comparison). Loopback binds (`127.0.0.1`/`localhost`) work
+  without a token, matching stdio's local-process trust level. Set
+  `MCP_HTTP_ALLOWED_HOSTS`/`MCP_HTTP_ALLOWED_ORIGINS` (comma-separated) to
+  enable DNS-rebinding protection for non-loopback binds. This is intended
+  for private networks (behind a VPN/Tailscale/SSH tunnel) — a static
+  shared token has none of OAuth's revocation/audit/expiry properties, so
+  avoid exposing it directly to the public internet even with a token set.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -144,6 +144,23 @@ Full design: [`docs/security/encryption-design.md`](docs/security/encryption-des
 - **Added `session-handoff` MCP Prompt**: scaffolds the Session Continuity workflow — takes `project` (required) plus optional `status`/`next_steps`/`blockers`, and returns instructions to call `get_or_create_note` + `add_text` with the canonical `Status:`/`Next:`/`Blockers:` format. 3 prompts total now (was 2).
 - **Spike: `simplenote://recent`-style auto-context resource — investigated, not building it.** MCP Resources in Claude Desktop are user-attached (picker/attachment UI), not automatically loaded into a conversation at session start — there's no mechanism in the MCP spec or Claude Desktop's client behavior for a server to push a resource into context proactively. A resource the user has to manually attach every session doesn't deliver the "automatic" value the original idea was chasing. The tool-based path (`search_notes`/`get_or_create_note`, now paired with the `session-handoff` prompt) already lets Claude *pull* project-state context autonomously at the start of a conversation, since tools — unlike resources — are always available for the model to call on its own initiative. That's the actual solution to this problem; a curated resource would be redundant with it.
 
+### Phase 11 — Security & Code Quality Audit Remediation ✅ (v1.21, unreleased)
+
+A full repository review (security, runtime correctness, deployment, dependencies, CI, test coverage) surfaced 12 findings, all resolved except the explicitly-deferred one:
+
+- **P0 — Secure HTTP transport**: `MCP_TRANSPORT=http` refuses to start on a non-loopback host without `MCP_HTTP_AUTH_TOKEN` (bearer token, constant-time check); `MCP_HTTP_ALLOWED_HOSTS`/`MCP_HTTP_ALLOWED_ORIGINS` enable DNS-rebinding protection.
+- **P0 — Stop logging note plaintext**: tool call arguments (note content, search queries) no longer dumped at INFO; sanitized form only at DEBUG.
+- **P1 — Real MCP errors**: tool failures return `CallToolResult(isError=True)` instead of looking like success at the protocol level; failed writes no longer consume the write budget.
+- **P1 — Fixed date-filtered search**: both ISO and natural-language (`yesterday`, `3_days_ago`, etc.) date filters now work end-to-end; the natural-language parser itself didn't handle its own advertised underscored format.
+- **P1 — Vault key fail-closed**: a corrupted key file/keychain entry is never silently overwritten with a fresh one; `vault_status` reports corruption instead of crashing.
+- **P1 — Per-client rate limiting/write budget**: real per-client identity (source IP for HTTP, fixed for stdio) replaces a dead decorator and a global `"default"` bucket.
+- **P1 — Repaired Docker/Helm runtime config**: the documented container path now actually serves requests; health/liveness/readiness probes hit real endpoints instead of just checking the package imports — which surfaced and fixed a separate bug where `/health` failed on merely "degraded" status, not just genuine failures.
+- **P1 — Restored the excluded test suite**: `simplenote_mcp/tests/` (112 tests) back in CI as an isolated pytest process; fixed the shared-mock bug behind most of its failures.
+- **P2 — Supply chain hardening**: all third-party GitHub Actions pinned to commit SHAs; reusable-workflow `secrets: inherit` narrowed to what's actually consumed; production Docker image installs runtime-only dependencies instead of the full dev/test/security toolchain.
+- **P2 — Config validation wired up**: `Config.validate()` now runs at startup instead of being dead code.
+- **P2 — Packaging metadata consolidated**: `setup.py`'s version/dependency drift fixed and now covered by the consistency checker.
+- **P3 — Deferred**: `tool_handlers.py`'s size (3,065 lines) and the 111 broad `except Exception` handlers need focused refactoring behind behavioral tests, not a broad rewrite — tracked as future work, not attempted in this pass.
+
 ### v2.0 Horizon
 
 | Item | Notes |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,19 +60,18 @@ For detailed information about our automated security monitoring and maintenance
 - **Command Injection Prevention**: Input filtering blocks command injection attempts
 
 ### Rate Limiting & DoS Protection
-- **Request Rate Limiting**: 100 requests per 5-minute window per client
-- **Progressive Penalties**: Automatic blocking for repeated violations
-- **Burst Protection**: Token bucket algorithm prevents traffic spikes
+- **Request Rate Limiting**: 60 requests/minute (burst) and 100 requests per 5-minute window (sustained), enforced per client — source IP for HTTP-transport callers, a fixed identifier for stdio (one local process is genuinely one client there). Both limits share one identity resolution mechanism (`server.py::_resolve_client_id`) so they can't be bypassed independently.
+- **Progressive Penalties**: Automatic blocking for repeated violations (1min → 5min → 15min → 1hour, scaling with violation count)
+- **Sliding-Window Enforcement**: rolling time-window counters per client identity
+- **Write Budget**: mutating tool calls (create/update/delete) are additionally capped per client per rolling window (`SIMPLENOTE_WRITE_BUDGET`, default 20/60s), independent of the general request rate limit, to bound the blast radius of a runaway automated loop
 - **Resource Limits**: Memory and processing time limits prevent resource exhaustion
 
 ### Authentication & Authorization
-- **Session Management**: Secure session tokens with configurable timeouts
-- **Failed Authentication Tracking**: Progressive blocking for failed login attempts
-- **Client Validation**: Client ID verification for session security
-- **Credential Protection**: Secure handling of Simplenote credentials
+- **MCP HTTP transport**: `MCP_TRANSPORT=http` refuses to start on a non-loopback `MCP_HTTP_HOST` unless `MCP_HTTP_AUTH_TOKEN` (a bearer token, checked via constant-time comparison) is configured. Loopback binds remain token-free, matching stdio's local-process trust model. `MCP_HTTP_ALLOWED_HOSTS`/`MCP_HTTP_ALLOWED_ORIGINS` enable DNS-rebinding protection for non-loopback binds. Intended for private-network use (behind a VPN/Tailscale/SSH tunnel) — a static shared token has none of OAuth's revocation/audit/expiry properties, so avoid exposing it directly to the public internet even with a token configured.
+- **Credential Protection**: Secure handling of Simplenote credentials (see Data Protection below for the local token cache)
 
 ### Data Protection
-- **Sensitive Data Redaction**: `password`/`token`/`secret`/`key` fields are redacted before logging or inclusion in tool-call error output (`security.py`, `middleware.py`)
+- **Sensitive Data Redaction**: `password`/`token`/`secret`/`key` fields are redacted before logging or inclusion in tool-call error output (`security.py`, `middleware.py`). Tool call arguments (note content, search queries) are never logged in full at INFO — only the tool name and argument count; a redacted/truncated form is available at DEBUG for troubleshooting.
 - **Secure Transmission**: HTTPS/TLS for all external communications (handled by the underlying `requests`/`urllib3`/`simplenote` client stack)
 - **Log Security**: Security events are logged with credential values redacted; log files themselves currently have no special filesystem permissions (tracked for hardening)
 - **No encryption at rest from Simplenote itself**: **Simplenote does not encrypt notes at rest on its own servers** — this is a limitation of the underlying service, not this project, and Automattic's own documentation recommends against storing highly sensitive information in Simplenote. Notes are NOT encrypted by default; only notes you explicitly opt into Vault (below) are protected.
@@ -80,6 +79,7 @@ For detailed information about our automated security monitoring and maintenance
   - **What Vault protects**: note body content, both in transit to Simplenote and at rest on Simplenote's servers.
   - **What Vault does NOT protect**: the note's title (first line — kept readable so `get_or_create_note`/browsing still work), tags, creation/modification timestamps, or the fact that a note exists at all. It also does not protect against a compromised local machine — the server process itself, and anyone with access to it, can read decrypted content and hold the encryption key.
   - **Key storage**: the Vault master key lives in the OS keychain (via the `keyring` library) or, for headless/container deployments, a file referenced by `SIMPLENOTE_VAULT_KEY_FILE` (`chmod 0600`). It is fetched once per process and cached in memory only — never written to disk in plaintext, never synced to Simplenote. There is no multi-device key sync in the current version: encrypted notes are only decryptable on a machine holding the matching key.
+  - **Fail-closed key handling**: a key file/keychain entry that exists but is unreadable, malformed, or the wrong length is never silently replaced with a freshly generated key — doing so would permanently orphan any notes already encrypted with the original. `vault_status` reports the corruption explicitly so it can be resolved deliberately.
 - **Local credential cache**: the Simperium auth token is cached locally at `~/.config/simplenote-mcp/<email>.token`, protected by `chmod 0600` (owner-only). This is a plaintext file, not OS-keychain-backed or encrypted — treat the same as any other locally-cached session token. (This is a different, lower-stakes secret than the Vault master key above — it's a rotatable session token, not the key that data confidentiality depends on.)
 
 ### Supply Chain Security
@@ -156,21 +156,27 @@ For detailed information about our automated security monitoring and maintenance
 
 ### Environment Variables
 ```bash
-# Security Configuration
+# Credentials
 SIMPLENOTE_EMAIL=your-email@example.com
 SIMPLENOTE_PASSWORD=your-secure-password
 SIMPLENOTE_OFFLINE_MODE=false
 
-# Session Configuration
-SESSION_TIMEOUT=3600  # 1 hour
-MAX_FAILED_ATTEMPTS=5
-RATE_LIMIT_WINDOW=300  # 5 minutes
-RATE_LIMIT_MAX_REQUESTS=100
+# MCP HTTP transport (only relevant if MCP_TRANSPORT=http)
+MCP_TRANSPORT=stdio  # or "http"
+MCP_HTTP_HOST=127.0.0.1
+MCP_HTTP_AUTH_TOKEN=  # required if MCP_HTTP_HOST is non-loopback
+MCP_HTTP_ALLOWED_HOSTS=  # comma-separated, enables DNS-rebinding protection
+MCP_HTTP_ALLOWED_ORIGINS=  # comma-separated
 
-# Logging Configuration
+# Rate limiting / write budget
+RATE_LIMIT_REQUESTS=100
+RATE_LIMIT_WINDOW_SECONDS=900
+RATE_LIMIT_BURST=20
+SIMPLENOTE_WRITE_BUDGET=20
+SIMPLENOTE_WRITE_BUDGET_WINDOW=60
+
+# Logging
 LOG_LEVEL=INFO
-SECURITY_LOG_LEVEL=WARNING
-AUDIT_LOG_ENABLED=true
 ```
 
 ### Docker Security

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: builder  # Use builder stage for development
+      target: builder # Use builder stage for development
     image: simplenote-mcp-server:dev
     container_name: simplenote-mcp-server-dev
 
@@ -13,13 +13,35 @@ services:
       - PYTHONUNBUFFERED=1
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONPATH=/app
+      # See docker-compose.yml for why these are needed — MCP_TRANSPORT
+      # defaults to stdio, so without them nothing listens on 8000 here
+      # either.
+      - MCP_TRANSPORT=http
+      - MCP_HTTP_HOST=0.0.0.0
+      - MCP_HTTP_AUTH_TOKEN=${MCP_HTTP_AUTH_TOKEN:?set MCP_HTTP_AUTH_TOKEN in .env — required for non-loopback MCP_TRANSPORT=http}
+      - ENABLE_HTTP_ENDPOINT=true
+      - HTTP_HOST=127.0.0.1
+      - HTTP_PORT=8080
 
     volumes:
-      - .:/app:ro  # Mount source code for development
+      - .:/app:ro # Mount source code for development
       - ./logs:/app/simplenote_mcp/logs
 
     ports:
       - "8000:8000"
+
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=5).status == 200 else 1)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
 
     # Override entrypoint for development
     command: ["python", "-m", "simplenote_mcp.server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,24 +15,45 @@ services:
       - SIMPLENOTE_PASSWORD=${SIMPLENOTE_PASSWORD}
       - PYTHONUNBUFFERED=1
       - PYTHONDONTWRITEBYTECODE=1
+      # MCP protocol over HTTP — MCP_HTTP_HOST=0.0.0.0 is the
+      # container-internal bind; Docker's own network/port publishing is
+      # the real access boundary. A bearer token is required: server.py's
+      # run_http() refuses to start a non-loopback bind without one.
+      - MCP_TRANSPORT=http
+      - MCP_HTTP_HOST=0.0.0.0
+      - MCP_HTTP_AUTH_TOKEN=${MCP_HTTP_AUTH_TOKEN:?set MCP_HTTP_AUTH_TOKEN in .env — required for non-loopback MCP_TRANSPORT=http}
+      # Separate health/metrics endpoint, loopback-only — used by the
+      # healthcheck below via docker exec, never published externally.
+      - ENABLE_HTTP_ENDPOINT=true
+      - HTTP_HOST=127.0.0.1
+      - HTTP_PORT=8080
 
     # Resource limits as per PRD requirements
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 512M
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 256M
 
-    # Health check
+    # Health check — a real probe against the monitoring server, not just
+    # an import check (which proves nothing about whether the process is
+    # actually serving requests). No curl in this image, so a Python
+    # one-liner against the loopback-only monitoring endpoint above.
     healthcheck:
-      test: ["CMD", "python", "-c", "import simplenote_mcp.server; print('ok')"]
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=5).status == 200 else 1)",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 10s
+      start_period: 15s
 
     # Volumes for persistent logs (optional)
     volumes:
@@ -43,7 +64,7 @@ services:
       - "8000:8000"
 
     # Security options
-    user: "1000:1000"  # Use host user ID to avoid permission issues
+    user: "1000:1000" # Use host user ID to avoid permission issues
     security_opt:
       - no-new-privileges:true
     read_only: true

--- a/helm/simplenote-mcp-server/templates/deployment.yaml
+++ b/helm/simplenote-mcp-server/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+            - name: monitoring
+              containerPort: {{ .Values.monitoring.port }}
+              protocol: TCP
           env:
             - name: SIMPLENOTE_EMAIL
               valueFrom:
@@ -51,6 +54,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "simplenote-mcp-server.secretName" . }}
                   key: SIMPLENOTE_PASSWORD
+            - name: MCP_HTTP_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "simplenote-mcp-server.secretName" . }}
+                  key: MCP_HTTP_AUTH_TOKEN
           envFrom:
             {{- if .Values.configMap.create }}
             - configMapRef:

--- a/helm/simplenote-mcp-server/templates/secret.yaml
+++ b/helm/simplenote-mcp-server/templates/secret.yaml
@@ -9,4 +9,5 @@ type: Opaque
 data:
   SIMPLENOTE_EMAIL: {{ .Values.simplenote.email | b64enc | quote }}
   SIMPLENOTE_PASSWORD: {{ .Values.simplenote.password | b64enc | quote }}
+  MCP_HTTP_AUTH_TOKEN: {{ .Values.mcpHttp.authToken | b64enc | quote }}
 {{- end }}

--- a/helm/simplenote-mcp-server/values.yaml
+++ b/helm/simplenote-mcp-server/values.yaml
@@ -31,7 +31,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
@@ -40,6 +40,12 @@ service:
   type: ClusterIP
   port: 8000
   targetPort: 8000
+
+# Separate health/metrics endpoint (ENABLE_HTTP_ENDPOINT below) — not the
+# MCP protocol port above. Used by liveness/readiness probes; not exposed
+# via the Service, only within the pod.
+monitoring:
+  port: 8080
 
 ingress:
   enabled: false
@@ -60,23 +66,22 @@ resources:
     cpu: 500m
     memory: 256Mi
 
+# Real probes against the monitoring server (ENABLE_HTTP_ENDPOINT=true in
+# configMap.data below) — an import-only exec check proves the package is
+# installed, not that the process is actually serving requests.
 livenessProbe:
-  exec:
-    command:
-      - python
-      - -c
-      - "import simplenote_mcp.server; print('ok')"
+  httpGet:
+    path: /health
+    port: monitoring
   initialDelaySeconds: 30
   periodSeconds: 30
   timeoutSeconds: 10
   failureThreshold: 3
 
 readinessProbe:
-  exec:
-    command:
-      - python
-      - -c
-      - "import simplenote_mcp.server; print('ok')"
+  httpGet:
+    path: /ready
+    port: monitoring
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 5
@@ -114,6 +119,14 @@ simplenote:
   syncIntervalSeconds: 120
   logLevel: "INFO"
 
+# MCP HTTP transport configuration
+mcpHttp:
+  # Bearer token required for MCP_TRANSPORT=http on a non-loopback bind —
+  # server.py's run_http() refuses to start otherwise. Provide via
+  # --set mcpHttp.authToken=... or a values override; never commit a real
+  # token. Stored in the same Secret as the Simplenote credentials below.
+  authToken: ""
+
 # External secrets configuration (optional)
 externalSecrets:
   enabled: false
@@ -130,6 +143,9 @@ externalSecrets:
     - secretKey: SIMPLENOTE_PASSWORD
       remoteRef:
         key: simplenote-password
+    - secretKey: MCP_HTTP_AUTH_TOKEN
+      remoteRef:
+        key: mcp-http-auth-token
 
 # ConfigMap for environment variables
 configMap:
@@ -139,3 +155,8 @@ configMap:
     LOG_LEVEL: "INFO"
     PYTHONUNBUFFERED: "1"
     PYTHONDONTWRITEBYTECODE: "1"
+    MCP_TRANSPORT: "http"
+    MCP_HTTP_HOST: "0.0.0.0"
+    ENABLE_HTTP_ENDPOINT: "true"
+    HTTP_HOST: "127.0.0.1"
+    HTTP_PORT: "8080"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4116 @@
+{
+  "name": "simplenote-mcp-server-evals",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "simplenote-mcp-server-evals",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tsx": "^4.20.3"
+      },
+      "devDependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@types/node": "^22.10.1",
+        "mcp-evals": "^2.0.1",
+        "typescript": "^5.7.2",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
+      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "1.3.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.23.tgz",
+      "integrity": "sha512-86U7rFp8yacUAOE/Jz8WbGcwMCqWvjK33wk5DXkfnAOEn3mx2r7tNSJdjukQFZbAK97VMXGPPHxF+aEARDXRXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.8.1.tgz",
+      "integrity": "sha512-59etePenCizVx1O8Qhi1T1ruE04ISfNzCnyhZNcsss1QljsLmYS83jttarMNEvGYcsUF7rwxw2lzcC3Zbxao7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.119",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.119.tgz",
+      "integrity": "sha512-d0F6m9itIPaKnrvEMlzE48UjwZaAnFW7Jwibacw9MNdqadjKNpUm9tfJYDwmShJmgqcoqYUX3EMKO1+RWiuuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
+      "integrity": "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.6.tgz",
+      "integrity": "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz",
+      "integrity": "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.6.tgz",
+      "integrity": "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz",
+      "integrity": "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz",
+      "integrity": "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz",
+      "integrity": "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz",
+      "integrity": "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz",
+      "integrity": "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz",
+      "integrity": "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz",
+      "integrity": "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz",
+      "integrity": "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz",
+      "integrity": "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz",
+      "integrity": "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz",
+      "integrity": "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz",
+      "integrity": "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz",
+      "integrity": "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz",
+      "integrity": "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz",
+      "integrity": "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz",
+      "integrity": "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz",
+      "integrity": "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
+      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
+      "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.0.tgz",
+      "integrity": "sha512-IEkJGzK1A9v3/EHjXh3s2IiFc6L4jfK+lNgKVgUjeUJQRRhnVFMIO3TAvKwonm9O1HebCuoOt98v8bZW7oVQHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.200.0.tgz",
+      "integrity": "sha512-+3MDfa5YQPGM3WXxW9kqGD85Q7s9wlEMVNhXXG7tYFLnIeaseUt9YtCeFhEDFzfEktacdFpOtXmJuNW8cHbU5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/sdk-logs": "0.200.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.200.0.tgz",
+      "integrity": "sha512-KfWw49htbGGp9s8N4KI8EQ9XuqKJ0VG+yVYVYFiCYSjEV32qpQ5qZ9UZBzOZ6xRb+E16SXOSCT3RkqBVSABZ+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/sdk-logs": "0.200.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.200.0.tgz",
+      "integrity": "sha512-GmahpUU/55hxfH4TP77ChOfftADsCq/nuri73I/AVLe2s4NIglvTsaACkFVZAVmnXXyPS00Fk3x27WS3yO07zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-logs": "0.200.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.200.0.tgz",
+      "integrity": "sha512-uHawPRvKIrhqH09GloTuYeq2BjyieYHIpiklOvxm9zhrCL2eRsnI/6g9v2BZTVtGp8tEgIa7rCQ6Ltxw6NBgew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-metrics": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.200.0.tgz",
+      "integrity": "sha512-5BiR6i8yHc9+qW7F6LqkuUnIzVNA7lt0qRxIKcKT+gq3eGUPHZ3DY29sfxI3tkvnwMgtnHDMNze5DdxW39HsAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-metrics": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.200.0.tgz",
+      "integrity": "sha512-E+uPj0yyvz81U9pvLZp3oHtFrEzNSqKGVkIViTQY1rH3TOobeJPSpLnTVXACnCwkPR5XeTvPnK3pZ2Kni8AFMg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-metrics": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.200.0.tgz",
+      "integrity": "sha512-ZYdlU9r0USuuYppiDyU2VFRA0kFl855ylnb3N/2aOlXrbA4PMCznen7gmPbetGQu7pz8Jbaf4fwvrDnVdQQXSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-metrics": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.200.0.tgz",
+      "integrity": "sha512-hmeZrUkFl1YMsgukSuHCFPYeF9df0hHoKeHUthRKFCxiURs+GwF1VuabuHmBMZnjTbsuvNjOB+JSs37Csem/5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.200.0.tgz",
+      "integrity": "sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.200.0.tgz",
+      "integrity": "sha512-V9TDSD3PjK1OREw2iT9TUTzNYEVWJk4Nhodzhp9eiz4onDMYmPy3LaGbPv81yIR6dUb/hNp/SIhpiCHwFUq2Vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.0.0.tgz",
+      "integrity": "sha512-icxaKZ+jZL/NHXX8Aru4HGsrdhK0MLcuRXkX5G5IRmCgoRLw+Br6I/nMVozX2xjGGwV7hw2g+4Slj8K7s4HbVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.200.0.tgz",
+      "integrity": "sha512-pmPlzfJd+vvgaZd/reMsC8RWgTXn2WY1OWT5RT42m3aOn5532TozwXNDhg1vzqJ+jnvmkREcdLr27ebJEQt0Jg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.200.0.tgz",
+      "integrity": "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-transformer": "0.200.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.200.0.tgz",
+      "integrity": "sha512-CK2S+bFgOZ66Bsu5hlDeOX6cvW5FVtVjFFbWuaJP0ELxJKBB6HlbLZQ2phqz/uLj1cWap5xJr/PsR3iGoB7Vqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.200.0.tgz",
+      "integrity": "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-logs": "0.200.0",
+        "@opentelemetry/sdk-metrics": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.0.0.tgz",
+      "integrity": "sha512-blx9S2EI49Ycuw6VZq+bkpaIoiJFhsDuvFGhBIoH3vJ5oYjJ2U0s3fAM5jYft99xVIAv6HqoPtlP9gpVA2IZtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.0.0.tgz",
+      "integrity": "sha512-Mbm/LSFyAtQKP0AQah4AfGgsD+vsZcyreZoQ5okFBk33hU7AquU4TltgyL9dvaO8/Zkoud8/0gEvwfOZ5d7EPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
+      "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
+      "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
+      "integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.200.0.tgz",
+      "integrity": "sha512-S/YSy9GIswnhYoDor1RusNkmRughipvTCOQrlF1dzI70yQaf68qgf5WMnzUxdlCl3/et/pvaO75xfPfuEmCK5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.200.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.200.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.200.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.200.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.200.0",
+        "@opentelemetry/exporter-prometheus": "0.200.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.200.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.200.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.200.0",
+        "@opentelemetry/exporter-zipkin": "2.0.0",
+        "@opentelemetry/instrumentation": "0.200.0",
+        "@opentelemetry/propagator-b3": "2.0.0",
+        "@opentelemetry/propagator-jaeger": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-logs": "0.200.0",
+        "@opentelemetry/sdk-metrics": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0",
+        "@opentelemetry/sdk-trace-node": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
+      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.0.tgz",
+      "integrity": "sha512-omdilCZozUjQwY3uZRBwbaRMJ3p09l4t187Lsdf0dGMye9WKD4NGcpgZRvqhI1dwcH6og+YXQEtoO9Wx3ykilg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.0.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
+      "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.16.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.4.tgz",
+      "integrity": "sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==",
+      "dev": true
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/digest-fetch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
+      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "md5": "^2.3.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
+      "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.6",
+        "@esbuild/android-arm": "0.25.6",
+        "@esbuild/android-arm64": "0.25.6",
+        "@esbuild/android-x64": "0.25.6",
+        "@esbuild/darwin-arm64": "0.25.6",
+        "@esbuild/darwin-x64": "0.25.6",
+        "@esbuild/freebsd-arm64": "0.25.6",
+        "@esbuild/freebsd-x64": "0.25.6",
+        "@esbuild/linux-arm": "0.25.6",
+        "@esbuild/linux-arm64": "0.25.6",
+        "@esbuild/linux-ia32": "0.25.6",
+        "@esbuild/linux-loong64": "0.25.6",
+        "@esbuild/linux-mips64el": "0.25.6",
+        "@esbuild/linux-ppc64": "0.25.6",
+        "@esbuild/linux-riscv64": "0.25.6",
+        "@esbuild/linux-s390x": "0.25.6",
+        "@esbuild/linux-x64": "0.25.6",
+        "@esbuild/netbsd-arm64": "0.25.6",
+        "@esbuild/netbsd-x64": "0.25.6",
+        "@esbuild/openbsd-arm64": "0.25.6",
+        "@esbuild/openbsd-x64": "0.25.6",
+        "@esbuild/openharmony-arm64": "0.25.6",
+        "@esbuild/sunos-x64": "0.25.6",
+        "@esbuild/win32-arm64": "0.25.6",
+        "@esbuild/win32-ia32": "0.25.6",
+        "@esbuild/win32-x64": "0.25.6"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
+      "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz",
+      "integrity": "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-evals": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mcp-evals/-/mcp-evals-2.0.1.tgz",
+      "integrity": "sha512-2RZQ8oYqzClUHRp4AX6856KquX0Bn9/h3gGRqLROmUOdAeZOHxtqV6fuVmuc3Ilu6uYiJcJ5Wu0R3X40v8MvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.10.0",
+        "@ai-sdk/anthropic": "^1.2.12",
+        "@ai-sdk/openai": "^1.3.17",
+        "@anthropic-ai/sdk": "^0.8.0",
+        "@modelcontextprotocol/sdk": "^1.11.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-node": "^0.200.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/js-yaml": "^4.0.9",
+        "ai": "^4.3.9",
+        "chalk": "^4.1.2",
+        "dotenv": "^16.3.1",
+        "express": "^5.1.0",
+        "js-yaml": "^4.1.0",
+        "openai": "^4.24.1",
+        "prom-client": "^15.1.3",
+        "tsx": "^4.19.3"
+      },
+      "bin": {
+        "mcp-eval": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.119",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.119.tgz",
+      "integrity": "sha512-d0F6m9itIPaKnrvEMlzE48UjwZaAnFW7Jwibacw9MNdqadjKNpUm9tfJYDwmShJmgqcoqYUX3EMKO1+RWiuuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
+      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -126,7 +126,6 @@ ruff==0.15.21
 setuptools==83.0.0
 shellingham==1.5.4
 simplenote==2.1.4
--e git+https://github.com/docdyhr/simplenote-mcp-server.git@55c40fcf53daadcd5c3ee1b6f251adb3ea4aba0d#egg=simplenote_mcp_server
 six==1.17.0
 smmap==5.0.3
 sniffio==1.3.1

--- a/requirements-runtime-lock.txt
+++ b/requirements-runtime-lock.txt
@@ -1,0 +1,68 @@
+# Runtime-only dependency lock for the production Docker image.
+#
+# Resolved from `pip install .` (pyproject.toml's core [project.dependencies]
+# only — no extras) in a clean virtualenv, then `pip freeze`. Does NOT
+# include dev/test/security tooling (ruff, mypy, bandit, pytest, build,
+# twine, pre-commit, etc.) — those come from the `dev`/`test`/`all` extras
+# and belong only in requirements-lock.txt (the full development lock),
+# never in the production image.
+#
+# Regenerate after changing pyproject.toml's core dependencies:
+#   python3 -m venv /tmp/runtime-lock-venv
+#   /tmp/runtime-lock-venv/bin/pip install .
+#   /tmp/runtime-lock-venv/bin/pip freeze | grep -v simplenote-mcp-server > requirements-runtime-lock.txt
+
+aiohappyeyeballs==2.7.1
+aiohttp==3.14.1
+aiosignal==1.4.0
+annotated-doc==0.0.4
+annotated-types==0.7.0
+anyio==4.14.2
+attrs==26.1.0
+certifi==2026.6.17
+cffi==2.1.0
+charset-normalizer==3.4.9
+click==8.4.2
+cryptography==49.0.0
+frozenlist==1.8.0
+h11==0.16.0
+httpcore==1.0.9
+httpx-sse==0.4.3
+httpx==0.28.1
+idna==3.18
+jaraco.classes==3.4.0
+jaraco.context==6.1.2
+jaraco.functools==4.5.0
+jsonschema-specifications==2025.9.1
+jsonschema==4.26.0
+keyring==25.7.0
+markdown-it-py==4.2.0
+mcp==1.28.1
+mdurl==0.1.2
+more-itertools==11.1.0
+multidict==6.7.1
+propcache==0.5.2
+pycparser==3.0
+pydantic_core==2.46.4
+pydantic-settings==2.14.2
+pydantic==2.13.4
+Pygments==2.20.0
+PyJWT==2.13.0
+python-dateutil==2.9.0.post0
+python-dotenv==1.2.2
+python-multipart==0.0.32
+referencing==0.37.0
+requests==2.34.2
+rich==15.0.0
+rpds-py==2026.6.3
+shellingham==1.5.4
+simplenote==2.1.4
+six==1.17.0
+sse-starlette==3.4.5
+starlette==1.3.1
+typer==0.26.8
+typing_extensions==4.16.0
+typing-inspection==0.4.2
+urllib3==2.7.0
+uvicorn==0.51.0
+yarl==1.24.2

--- a/scripts/quality/check_version_consistency.py
+++ b/scripts/quality/check_version_consistency.py
@@ -7,6 +7,7 @@ consistent. It checks:
 - pyproject.toml
 - simplenote_mcp/__init__.py
 - helm/simplenote-mcp-server/Chart.yaml
+- setup.py (legacy fallback; pyproject.toml is the actual build source of truth)
 
 Usage:
     python scripts/quality/check_version_consistency.py
@@ -103,6 +104,27 @@ def read_helm_version(root: Path) -> str | None:
                 return match.group(1)
     except Exception as e:
         print(f"Error reading Chart.yaml: {e}", file=sys.stderr)
+    return None
+
+
+def read_setup_py_version(root: Path) -> str | None:
+    """Read version from setup.py.
+
+    Args:
+        root: Project root directory
+
+    Returns:
+        Version string or None if not found
+    """
+    setup_py_file = root / "setup.py"
+    try:
+        if setup_py_file.exists():
+            content = setup_py_file.read_text()
+            match = re.search(r'version\s*=\s*"([^"]+)"', content)
+            if match:
+                return match.group(1)
+    except Exception as e:
+        print(f"Error reading setup.py: {e}", file=sys.stderr)
     return None
 
 
@@ -208,6 +230,28 @@ def update_helm_version(root: Path, version: str) -> bool:
         return False
 
 
+def update_setup_py_version(root: Path, version: str) -> bool:
+    """Update version in setup.py.
+
+    Args:
+        root: Project root directory
+        version: Version string to write
+
+    Returns:
+        True if successful, False otherwise
+    """
+    setup_py_file = root / "setup.py"
+    try:
+        content = setup_py_file.read_text()
+        updated = re.sub(r'version\s*=\s*"[^"]+"', f'version="{version}"', content)
+        setup_py_file.write_text(updated)
+        print(f"✅ Updated setup.py to {version}")
+        return True
+    except Exception as e:
+        print(f"❌ Error updating setup.py: {e}", file=sys.stderr)
+        return False
+
+
 def check_versions(root: Path) -> dict[str, str | None]:
     """Check all version sources and return their values.
 
@@ -222,6 +266,7 @@ def check_versions(root: Path) -> dict[str, str | None]:
         "pyproject.toml": read_pyproject_version(root),
         "__init__.py": read_init_version(root),
         "Chart.yaml": read_helm_version(root),
+        "setup.py": read_setup_py_version(root),
     }
     return versions
 
@@ -299,6 +344,8 @@ def main() -> int:
             success &= update_init_version(root, target_version)
         if versions.get("Chart.yaml") != target_version:
             success &= update_helm_version(root, target_version)
+        if versions.get("setup.py") != target_version:
+            success &= update_setup_py_version(root, target_version)
 
         if success:
             print("\n✅ All versions have been synchronized!")

--- a/scripts/test-docker-ci.sh
+++ b/scripts/test-docker-ci.sh
@@ -35,6 +35,65 @@ test_docker_run() {
     fi
 }
 
+test_docker_http_serves_requests() {
+    echo -e "\n${YELLOW}Testing that the container actually serves MCP requests over HTTP...${NC}"
+    # test_docker_run() above only proves the binary starts (--help exits
+    # 0) — it never proves the process accepts a connection and speaks the
+    # protocol. This starts the real container with MCP_TRANSPORT=http and
+    # drives an actual HTTP request against it, both without and with the
+    # required bearer token.
+
+    local port=18790
+    local token="docker-ci-smoke-test-token"
+    local container_id
+
+    container_id=$(docker run -d \
+        -e SIMPLENOTE_OFFLINE_MODE=true \
+        -e MCP_TRANSPORT=http \
+        -e MCP_HTTP_HOST=0.0.0.0 \
+        -e MCP_HTTP_AUTH_TOKEN="$token" \
+        -e LOG_TO_FILE=false \
+        -p "${port}:8000" \
+        simplenote-mcp-server:test)
+
+    # Give the server a moment to bind the port.
+    local waited=0
+    while [ "$waited" -lt 20 ]; do
+        if curl -s -o /dev/null "http://127.0.0.1:${port}/mcp" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    local unauth_status
+    unauth_status=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X POST "http://127.0.0.1:${port}/mcp" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-test","version":"1.0"}}}')
+
+    local auth_status
+    auth_status=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X POST "http://127.0.0.1:${port}/mcp" \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-test","version":"1.0"}}}')
+
+    docker logs "$container_id" 2>&1 | tail -30
+    docker stop "$container_id" > /dev/null 2>&1 || true
+    docker rm "$container_id" > /dev/null 2>&1 || true
+
+    if [ "$unauth_status" = "401" ] && [ "$auth_status" = "200" ]; then
+        echo -e "${GREEN}✓ Container serves MCP over HTTP (401 unauthenticated, 200 authenticated)${NC}"
+        return 0
+    else
+        echo -e "${RED}✗ Container did not serve requests as expected (unauth=${unauth_status}, auth=${auth_status})${NC}"
+        return 1
+    fi
+}
+
 test_docker_compose() {
     echo -e "\n${YELLOW}Testing Docker Compose...${NC}"
 
@@ -129,7 +188,7 @@ TESTS_PASSED=0
 TESTS_FAILED=0
 
 # Run each test and track results
-for test in test_docker_build test_docker_run test_docker_compose test_multi_platform_build test_workflow_syntax test_dockerfile_best_practices; do
+for test in test_docker_build test_docker_run test_docker_http_serves_requests test_docker_compose test_multi_platform_build test_workflow_syntax test_dockerfile_best_practices; do
     if $test; then
         ((TESTS_PASSED++))
     else

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,33 @@
-"""Setup configuration for the Simplenote MCP Server package."""
+"""Setup configuration for the Simplenote MCP Server package.
+
+Legacy fallback only — pyproject.toml's [project] table (PEP 621) is the
+authoritative source of truth for name/version/dependencies and is what
+`pip install .`/the Dockerfile build actually resolve against; modern
+setuptools ignores this file's arguments once pyproject.toml has a full
+[project] table. Kept in sync manually (see
+scripts/quality/check_version_consistency.py, which checks this file's
+version against VERSION/pyproject.toml/__init__.py/Chart.yaml) for any
+older tooling that still expects a setup.py to exist.
+"""
 
 from setuptools import find_packages, setup
 
 setup(
     name="simplenote-mcp-server",
-    version="1.12.0",
-    description="Simplenote MCP Server for Claude Desktop",
+    version="1.17.1",
+    description="A simple MCP Server that connects to Simplenote",
     packages=find_packages(),
     install_requires=[
         "mcp[cli]>=1.10.0",
         "simplenote>=2.1.4",
-        "requests>=2.32.4",
+        "requests>=2.33.0",
+        "starlette>=0.49.1",
+        "uvicorn>=0.44.0",
+        "urllib3>=2.6.3",
+        "aiohttp>=3.9.0",
+        "python-dateutil>=2.8.0",
+        "cryptography>=44.0.0",
+        "keyring>=24.0.0",
     ],
     entry_points={
         "console_scripts": [

--- a/simplenote_mcp/server/config.py
+++ b/simplenote_mcp/server/config.py
@@ -98,6 +98,24 @@ class Config:
         self.mcp_http_port: int = int(os.environ.get("MCP_HTTP_PORT", "8000"))
         self.mcp_http_path: str = os.environ.get("MCP_HTTP_PATH", "/mcp")
 
+        # MCP HTTP transport security. A bearer token is required to bind
+        # MCP_TRANSPORT=http to any non-loopback host (see run_http()) — the
+        # server refuses to start otherwise. Loopback binds work token-free,
+        # matching stdio's local-process trust level.
+        self.mcp_http_auth_token: str | None = (
+            os.environ.get("MCP_HTTP_AUTH_TOKEN") or None
+        )
+        self.mcp_http_allowed_hosts: list[str] = [
+            h.strip()
+            for h in os.environ.get("MCP_HTTP_ALLOWED_HOSTS", "").split(",")
+            if h.strip()
+        ]
+        self.mcp_http_allowed_origins: list[str] = [
+            o.strip()
+            for o in os.environ.get("MCP_HTTP_ALLOWED_ORIGINS", "").split(",")
+            if o.strip()
+        ]
+
         # Logging configuration - check multiple possible environment variable names
         log_level_env = (
             os.environ.get("LOG_LEVEL")

--- a/simplenote_mcp/server/http_endpoints.py
+++ b/simplenote_mcp/server/http_endpoints.py
@@ -271,7 +271,14 @@ class HTTPEndpointsHandler(BaseHTTPRequestHandler):
 
         health_data = self.health_status.to_dict()
 
-        status_code = 200 if health_data["status"] == "healthy" else 503
+        # Only a genuine "unhealthy" check (e.g. an exception while probing
+        # a subsystem) fails the HTTP status — "degraded" (e.g. a low cache
+        # hit rate, which is completely normal right after startup or
+        # during a quiet period) still means the process is up and able to
+        # serve, so it must not fail liveness/readiness probes wired to
+        # this endpoint. The degraded detail is still visible in the JSON
+        # body for anyone actually monitoring it.
+        status_code = 503 if health_data["status"] == "unhealthy" else 200
         if status_code != 200:
             logger.warning(f"Server unhealthy: {health_data}")
 

--- a/simplenote_mcp/server/middleware.py
+++ b/simplenote_mcp/server/middleware.py
@@ -257,6 +257,24 @@ class RateLimiter:
             logger.warning(f"Failed to trigger rate limit alert: {e}")
 
 
+def sanitize_arguments_for_logging(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Redact/truncate tool arguments so they're safe to log.
+
+    Redacts fields whose name suggests a secret (password/token/secret/key)
+    and truncates long string values (note content, search queries) rather
+    than logging them in full.
+    """
+    sanitized = {}
+    for key, value in arguments.items():
+        if key.lower() in ["password", "token", "secret", "key"]:
+            sanitized[key] = "[REDACTED]"
+        elif isinstance(value, str) and len(value) > 100:
+            sanitized[key] = value[:100] + "... [TRUNCATED]"
+        else:
+            sanitized[key] = value
+    return sanitized
+
+
 class RequestValidator:
     """Comprehensive request validation middleware."""
 
@@ -426,15 +444,7 @@ class RequestValidator:
 
     def _sanitize_arguments(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Sanitize arguments for logging (remove sensitive data)."""
-        sanitized = {}
-        for key, value in arguments.items():
-            if key.lower() in ["password", "token", "secret", "key"]:
-                sanitized[key] = "[REDACTED]"
-            elif isinstance(value, str) and len(value) > 100:
-                sanitized[key] = value[:100] + "... [TRUNCATED]"
-            else:
-                sanitized[key] = value
-        return sanitized
+        return sanitize_arguments_for_logging(arguments)
 
 
 class AuthenticationMiddleware:

--- a/simplenote_mcp/server/search/date_parser.py
+++ b/simplenote_mcp/server/search/date_parser.py
@@ -80,8 +80,11 @@ def parse_natural_date(text: str) -> datetime | None:
         result = datetime.now() - delta
         return result.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Re-normalize with spaces for pattern matching
-    spaced = text.strip().lower()
+    # Re-normalize with spaces for pattern matching. The tool schema
+    # advertises underscored examples (e.g. "3_days_ago", "last_monday"),
+    # matching the keyword style above — accept those alongside naturally
+    # spaced input for the regex patterns below, which require whitespace.
+    spaced = text.strip().lower().replace("_", " ")
 
     # Check "N unit(s) ago" pattern
     ago_match = _AGO_PATTERN.match(spaced)

--- a/simplenote_mcp/server/security.py
+++ b/simplenote_mcp/server/security.py
@@ -262,60 +262,67 @@ class SecurityValidator:
 
     def validate_date_range(
         self, from_date: Any = None, to_date: Any = None
-    ) -> tuple[datetime | None, datetime | None]:
+    ) -> tuple[str | datetime | None, str | datetime | None]:
         """Validate date range parameters.
 
+        Accepts ISO-format strings, natural-language date expressions (see
+        search.date_parser.parse_natural_date — "yesterday", "last_week",
+        "3_days_ago", etc.), or datetime objects. Returns the *original*
+        value unchanged rather than a parsed datetime: this method only
+        checks that each value is parseable and that the range is sane —
+        the search handler's own date parser (tool_handlers._parse_date)
+        is the single place that actually converts strings to datetimes,
+        so it must keep receiving the type it was given.
+
         Args:
-            from_date: Start date (ISO format string or datetime)
-            to_date: End date (ISO format string or datetime)
+            from_date: Start date (ISO string, natural-language string, or
+                datetime)
+            to_date: End date (ISO string, natural-language string, or
+                datetime)
 
         Returns:
-            Tuple of (validated_from_date, validated_to_date)
+            Tuple of (from_date, to_date), unchanged from the input.
 
         Raises:
-            ValidationError: If dates are invalid
+            ValidationError: If either value is an unparseable string/type,
+                or the range itself is invalid (from after to, or > 10 years).
         """
-        validated_from = None
-        validated_to = None
 
-        if from_date is not None:
-            if isinstance(from_date, str):
-                try:
-                    validated_from = datetime.fromisoformat(
-                        from_date.replace("Z", "+00:00")
-                    )
-                except ValueError as e:
+        def _check(
+            value: Any, field_name: str
+        ) -> tuple[str | datetime | None, datetime | None]:
+            if value is None:
+                return None, None
+            if isinstance(value, datetime):
+                return value, value
+            if not isinstance(value, str):
+                raise ValidationError(f"{field_name} must be a string or datetime")
+            try:
+                return value, datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                from .search.date_parser import parse_natural_date
+
+                parsed = parse_natural_date(value)
+                if parsed is None:
                     raise ValidationError(
-                        f"Invalid from_date format: {from_date}"
-                    ) from e
-            elif isinstance(from_date, datetime):
-                validated_from = from_date
-            else:
-                raise ValidationError("from_date must be a string or datetime")
+                        f"Invalid {field_name} format: {value}"
+                    ) from None
+                return value, parsed
 
-        if to_date is not None:
-            if isinstance(to_date, str):
-                try:
-                    validated_to = datetime.fromisoformat(
-                        to_date.replace("Z", "+00:00")
-                    )
-                except ValueError as e:
-                    raise ValidationError(f"Invalid to_date format: {to_date}") from e
-            elif isinstance(to_date, datetime):
-                validated_to = to_date
-            else:
-                raise ValidationError("to_date must be a string or datetime")
+        from_original, from_parsed = _check(from_date, "from_date")
+        to_original, to_parsed = _check(to_date, "to_date")
 
-        # Validate date range logic
-        if validated_from and validated_to:
-            if validated_from > validated_to:
+        # Validate date range logic using the parsed values for comparison
+        # only — the return still carries the original, unparsed value.
+        if from_parsed and to_parsed:
+            if from_parsed > to_parsed:
                 raise ValidationError("from_date must be before to_date")
 
             # Prevent extremely large date ranges (potential DoS)
-            if (validated_to - validated_from).days > 3650:  # 10 years
+            if (to_parsed - from_parsed).days > 3650:  # 10 years
                 raise ValidationError("Date range too large (max 10 years)")
 
-        return validated_from, validated_to
+        return from_original, to_original
 
     def validate_uri(self, uri: str, allowed_schemes: list[str] = None) -> None:
         """Validate URI for security issues.

--- a/simplenote_mcp/server/server.py
+++ b/simplenote_mcp/server/server.py
@@ -185,6 +185,68 @@ except Exception as e:
 simplenote_client = None
 
 
+def _build_offline_mock_client() -> Any:
+    """Build a stateful mock Simplenote client for SIMPLENOTE_OFFLINE_MODE.
+
+    A plain MagicMock with static return_values can't satisfy realistic
+    round-trip tests (create a note, then retrieve/update it and expect
+    the same content back) — add_note/get_note/update_note need to share
+    an in-memory store, like a real API would. Scoped to one closure per
+    call, so each fresh client (e.g. after clear_client_cache()) starts
+    with an empty store rather than leaking notes across tests.
+    """
+    from unittest.mock import MagicMock
+
+    mock_client = MagicMock()
+    notes_store: dict[str, dict[str, Any]] = {}
+    next_id = [1]
+
+    def mock_add_note(note: dict[str, Any], *_args: Any, **_kwargs: Any) -> Any:
+        key = f"mock-note-{next_id[0]}"
+        next_id[0] += 1
+        now = time.time()
+        stored = {
+            "key": key,
+            "content": note.get("content", ""),
+            "tags": list(note.get("tags", [])),
+            "systemTags": list(note.get("systemTags", [])),
+            "deleted": False,
+            "createdate": now,
+            "modifydate": now,
+        }
+        notes_store[key] = stored
+        return dict(stored), 0
+
+    def mock_get_note(note_id: str, *_args: Any, **_kwargs: Any) -> Any:
+        stored = notes_store.get(note_id)
+        if stored is None:
+            return None, -1
+        return dict(stored), 0
+
+    def mock_update_note(note: dict[str, Any], *_args: Any, **_kwargs: Any) -> Any:
+        key = note.get("key")
+        stored = notes_store.get(key) if key else None
+        if stored is None:
+            return None, -1
+        stored["content"] = note.get("content", stored["content"])
+        stored["tags"] = list(note.get("tags", stored["tags"]))
+        stored["modifydate"] = time.time()
+        return dict(stored), 0
+
+    def mock_trash_note(note_id: str, *_args: Any, **_kwargs: Any) -> int:
+        stored = notes_store.get(note_id)
+        if stored is not None:
+            stored["deleted"] = True
+        return 0
+
+    mock_client.get_note_list.return_value = ([], 0)
+    mock_client.get_note.side_effect = mock_get_note
+    mock_client.add_note.side_effect = mock_add_note
+    mock_client.update_note.side_effect = mock_update_note
+    mock_client.trash_note.side_effect = mock_trash_note
+    return mock_client
+
+
 def get_simplenote_client() -> Simplenote:
     """Get or create the Simplenote client.
 
@@ -206,17 +268,7 @@ def get_simplenote_client() -> Simplenote:
             # Check if running in offline mode
             if config.offline_mode:
                 logger.info("Running in offline mode - using mock Simplenote client")
-                from unittest.mock import MagicMock
-
-                # Create a mock client for offline mode
-                mock_client = MagicMock()
-                mock_client.get_note_list.return_value = ([], 0)
-                mock_client.get_note.return_value = ({}, 0)
-                mock_client.add_note.return_value = ({}, 0)
-                mock_client.update_note.return_value = ({}, 0)
-                mock_client.trash_note.return_value = 0
-
-                simplenote_client = mock_client
+                simplenote_client = _build_offline_mock_client()
                 logger.info("Mock Simplenote client created for offline mode")
                 return simplenote_client
 

--- a/simplenote_mcp/server/server.py
+++ b/simplenote_mcp/server/server.py
@@ -3,6 +3,7 @@
 # Import standard libraries
 import asyncio
 import atexit
+import hmac
 import json
 import os
 import signal
@@ -23,6 +24,9 @@ from mcp.server.lowlevel.helper_types import (  # type: ignore  # noqa: E402
     ReadResourceContents,
 )
 from mcp.server.models import InitializationOptions  # type: ignore  # noqa: E402
+from mcp.server.transport_security import (  # type: ignore  # noqa: E402
+    TransportSecuritySettings,
+)
 
 # External imports
 from pydantic import AnyUrl  # type: ignore  # noqa: E402
@@ -39,6 +43,7 @@ from .error_helpers import (
 )
 from .errors import (  # noqa: E402
     AuthenticationError,
+    ConfigurationError,
     ResourceNotFoundError,
     ServerError,
     ValidationError,
@@ -46,6 +51,7 @@ from .errors import (  # noqa: E402
 )
 from .logging import logger  # noqa: E402
 from .middleware import (
+    sanitize_arguments_for_logging,
     with_rate_limiting,
     with_request_validation,
     with_security_monitoring,
@@ -1675,7 +1681,11 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
     from .cache_utils import get_cache_or_create_minimal
     from .tool_handlers import ToolHandlerRegistry
 
-    logger.info(f"Tool call: {name} with arguments: {json.dumps(arguments)}")
+    logger.info(f"Tool call: {name} (args_count={len(arguments)})")
+    logger.debug(
+        f"Tool call {name} arguments: "
+        f"{json.dumps(sanitize_arguments_for_logging(arguments))}"
+    )
 
     # Record tool call for performance monitoring
     record_tool_call(name)
@@ -2105,6 +2115,53 @@ async def run() -> None:
         await _stop_background_sync()
 
 
+def _is_loopback_host(host: str) -> bool:
+    """Return True if host is a loopback address (127.0.0.1, localhost, ::1)."""
+    return host in ("127.0.0.1", "localhost", "::1")
+
+
+def _bearer_token_valid(scope: Any, expected_token: str) -> bool:
+    """Check the ASGI scope's Authorization header against expected_token.
+
+    Uses constant-time comparison to avoid leaking token length/prefix via
+    timing. `scope["headers"]` is a list of (name, value) byte-string pairs
+    per the ASGI spec.
+    """
+    headers = dict(scope.get("headers") or [])
+    raw = headers.get(b"authorization", b"").decode("latin-1")
+    if not raw.startswith("Bearer "):
+        return False
+    return hmac.compare_digest(raw[len("Bearer ") :], expected_token)
+
+
+def _build_http_security_settings(config: Any, host: str) -> TransportSecuritySettings:
+    """Build TransportSecuritySettings for the MCP HTTP transport.
+
+    Omitting security_settings entirely leaves DNS-rebinding protection off
+    (the SDK's own default). We always pass an explicit value: a safe
+    zero-config allowlist for loopback binds, the configured allowlist for
+    anything else, or — only if the operator hasn't configured one — a
+    logged, explicit opt-out rather than a silent one.
+    """
+    if config.mcp_http_allowed_hosts:
+        return TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=config.mcp_http_allowed_hosts,
+            allowed_origins=config.mcp_http_allowed_origins,
+        )
+    if _is_loopback_host(host):
+        return TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=["127.0.0.1:*", "localhost:*"],
+            allowed_origins=config.mcp_http_allowed_origins,
+        )
+    logger.warning(
+        "DNS rebinding protection disabled — set MCP_HTTP_ALLOWED_HOSTS to "
+        "enable it for non-loopback binds."
+    )
+    return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+
+
 async def run_http(host: str, port: int, path: str) -> None:
     """Run the server using streamable HTTP transport."""
     import time as time_module
@@ -2112,14 +2169,26 @@ async def run_http(host: str, port: int, path: str) -> None:
     import uvicorn
     from starlette.responses import PlainTextResponse
 
+    config = get_config()
+
+    if not _is_loopback_host(host) and not config.mcp_http_auth_token:
+        raise ConfigurationError(
+            f"Refusing to start MCP_TRANSPORT=http on non-loopback host "
+            f"{host!r} without MCP_HTTP_AUTH_TOKEN set. Set a bearer token, "
+            "or bind MCP_HTTP_HOST to 127.0.0.1/localhost for same-host-only "
+            "access.",
+            subcategory="http_auth_required",
+        )
+
     startup_start = time_module.time()
     normalized_path = path if path.startswith("/") else f"/{path}"
     logger.info(
         f"Starting MCP server HTTP transport on http://{host}:{port}{normalized_path}"
     )
 
+    security_settings = _build_http_security_settings(config, host)
     transport = mcp.server.streamable_http.StreamableHTTPServerTransport(
-        mcp_session_id=None
+        mcp_session_id=None, security_settings=security_settings
     )
 
     try:
@@ -2153,6 +2222,17 @@ async def run_http(host: str, port: int, path: str) -> None:
                 request_path = cast(str, scope.get("path", ""))
                 if request_path != normalized_path:
                     response = PlainTextResponse("Not Found", status_code=404)
+                    await response(scope, receive, send)
+                    return
+
+                if config.mcp_http_auth_token and not _bearer_token_valid(
+                    scope, config.mcp_http_auth_token
+                ):
+                    response = PlainTextResponse(
+                        "Unauthorized",
+                        status_code=401,
+                        headers={"WWW-Authenticate": "Bearer"},
+                    )
                     await response(scope, receive, send)
                     return
 

--- a/simplenote_mcp/server/server.py
+++ b/simplenote_mcp/server/server.py
@@ -2407,6 +2407,12 @@ def run_main() -> None:
         # Configure logging from environment variables
         config = get_config()
 
+        # Fail fast on invalid configuration — before logging setup, PID
+        # file creation, or any background thread starts. Config.validate()
+        # raises ValueError, which the outer except below already handles
+        # correctly (log critical, clean up the PID file, exit 1).
+        config.validate()
+
         # Add debug information for environment variables to a safe debug file
         from .logging import debug_to_file
 

--- a/simplenote_mcp/server/server.py
+++ b/simplenote_mcp/server/server.py
@@ -1663,7 +1663,9 @@ async def handle_list_tools() -> list[types.Tool]:
 @with_security_monitoring()
 @with_rate_limiting(max_requests=100, window_seconds=300)  # 100 requests per 5 minutes
 @with_request_validation()
-async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+async def handle_call_tool(
+    name: str, arguments: dict
+) -> list[types.TextContent] | types.CallToolResult:
     """Handle the call_tool capability using the new tool handler system.
 
     Args:
@@ -1714,9 +1716,12 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
                     "Set SIMPLENOTE_WRITE_MODE=true to enable write operations.",
                     subcategory="write_mode_disabled",
                 )
-                return [
-                    types.TextContent(type="text", text=json.dumps(error.to_dict()))
-                ]
+                return types.CallToolResult(
+                    content=[
+                        types.TextContent(type="text", text=json.dumps(error.to_dict()))
+                    ],
+                    isError=True,
+                )
             _check_write_budget()
 
         # Get handler from registry
@@ -1727,22 +1732,36 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
             error_msg = UNKNOWN_TOOL_ERROR.format(name=name)
             logger.error(error_msg)
             error = ValidationError(error_msg)
-            return [types.TextContent(type="text", text=json.dumps(error.to_dict()))]
+            return types.CallToolResult(
+                content=[
+                    types.TextContent(type="text", text=json.dumps(error.to_dict()))
+                ],
+                isError=True,
+            )
 
-        # Execute the tool handler and record the write if it succeeded.
+        # Execute the tool handler and record the write only if it succeeded —
+        # a handler-level failure (isError=True) must not consume write budget.
         result = await handler.handle(arguments)
         if name in WRITE_TOOLS:
-            _record_write()
+            is_error = isinstance(result, types.CallToolResult) and result.isError
+            if not is_error:
+                _record_write()
         return result
 
     except Exception as e:
         if isinstance(e, ServerError):
             error_dict = e.to_dict()
-            return [types.TextContent(type="text", text=json.dumps(error_dict))]
+            return types.CallToolResult(
+                content=[types.TextContent(type="text", text=json.dumps(error_dict))],
+                isError=True,
+            )
 
         logger.error(f"Error in tool call: {str(e)}", exc_info=True)
         error = handle_exception(e, f"calling tool {name}")
-        return [types.TextContent(type="text", text=json.dumps(error.to_dict()))]
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=json.dumps(error.to_dict()))],
+            isError=True,
+        )
 
 
 # ===== PROMPT CAPABILITIES =====

--- a/simplenote_mcp/server/server.py
+++ b/simplenote_mcp/server/server.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import threading
 import time
-from collections import deque
+from collections import defaultdict, deque
 from collections.abc import Iterable
 from typing import Any, cast
 
@@ -37,7 +37,6 @@ from .cache import BackgroundSync, NoteCache  # noqa: E402
 # Use our compatibility module for cross-version support
 from .compat import Path  # noqa: E402
 from .config import LogLevel, get_config  # noqa: E402
-from .decorators import rate_limit
 from .error_helpers import (
     format_error,
 )
@@ -134,14 +133,17 @@ WRITE_TOOLS: frozenset[str] = frozenset(
     }
 )
 
-# Per-session rolling write-budget tracker (not reset across reconnects —
+# Per-client rolling write-budget tracker (not reset across reconnects —
 # intentional: keeps the guard effective during a single server process).
-_write_timestamps: deque[float] = deque()
+# Keyed by client identifier (see _resolve_client_id) so one HTTP client
+# can't exhaust the budget for every other concurrent client; stdio has
+# exactly one implicit client per process, so it gets one shared bucket.
+_write_timestamps: dict[str, deque[float]] = defaultdict(deque)
 _write_budget_lock = threading.Lock()
 
 
-def _check_write_budget() -> None:
-    """Raise ValidationError if the session write budget is exhausted.
+def _check_write_budget(client_id: str) -> None:
+    """Raise ValidationError if client_id's write budget is exhausted.
 
     Uses a rolling window defined by config write_budget_max /
     write_budget_window_seconds.  Called immediately before each write tool
@@ -151,9 +153,10 @@ def _check_write_budget() -> None:
     now = time.monotonic()
     window_start = now - config.write_budget_window_seconds
     with _write_budget_lock:
-        while _write_timestamps and _write_timestamps[0] < window_start:
-            _write_timestamps.popleft()
-        if len(_write_timestamps) >= config.write_budget_max:
+        timestamps = _write_timestamps[client_id]
+        while timestamps and timestamps[0] < window_start:
+            timestamps.popleft()
+        if len(timestamps) >= config.write_budget_max:
             raise ValidationError(
                 f"Write budget exhausted: {config.write_budget_max} writes in "
                 f"{config.write_budget_window_seconds}s. "
@@ -162,10 +165,10 @@ def _check_write_budget() -> None:
             )
 
 
-def _record_write() -> None:
-    """Record a successful write operation against the session budget."""
+def _record_write(client_id: str) -> None:
+    """Record a successful write operation against client_id's budget."""
     with _write_budget_lock:
-        _write_timestamps.append(time.monotonic())
+        _write_timestamps[client_id].append(time.monotonic())
 
 
 # Create a server instance
@@ -1658,10 +1661,47 @@ async def handle_list_tools() -> list[types.Tool]:
         ]
 
 
-@rate_limit(60, 60)
+def _resolve_client_id(*_args: Any, **_kwargs: Any) -> str:
+    """Per-client identifier for rate limiting and the write budget.
+
+    stdio: one fixed identifier — a single local process IS one client for
+    that transport, which is correct behavior, not a gap, since there's
+    never more than one caller sharing a process. HTTP: the peer's source
+    IP, so concurrent callers sharing one MCP_HTTP_AUTH_TOKEN are still
+    isolated from each other rather than sharing a single global bucket.
+
+    Built on confirmed SDK internals: server.request_context.request
+    reliably carries the raw Starlette Request (with a real peer address)
+    for every HTTP-transport call, and is reliably None for stdio — see
+    run_http()/the streamable_http transport for how that's populated.
+
+    Signature matches with_rate_limiting's identifier_func(*args, **kwargs)
+    calling convention (invoked with handle_call_tool's own (name,
+    arguments)) — both are unused here.
+    """
+    try:
+        ctx = server.request_context
+    except LookupError:
+        return "stdio-local"
+    request = ctx.request
+    if request is None:
+        return "stdio-local"
+    client = getattr(request, "client", None)
+    return f"http:{client.host}" if client else "http:unknown"
+
+
 @server.call_tool()
 @with_security_monitoring()
-@with_rate_limiting(max_requests=100, window_seconds=300)  # 100 requests per 5 minutes
+@with_rate_limiting(
+    max_requests=100,
+    window_seconds=300,
+    identifier_func=_resolve_client_id,
+)  # sustained: 100 requests per 5 minutes, per client
+@with_rate_limiting(
+    max_requests=60,
+    window_seconds=60,
+    identifier_func=_resolve_client_id,
+)  # burst: 60 requests per minute, per client
 @with_request_validation()
 async def handle_call_tool(
     name: str, arguments: dict
@@ -1691,6 +1731,8 @@ async def handle_call_tool(
 
     # Record tool call for performance monitoring
     record_tool_call(name)
+
+    client_id = _resolve_client_id()
 
     try:
         # Record API call
@@ -1722,7 +1764,7 @@ async def handle_call_tool(
                     ],
                     isError=True,
                 )
-            _check_write_budget()
+            _check_write_budget(client_id)
 
         # Get handler from registry
         registry = ToolHandlerRegistry()
@@ -1745,7 +1787,7 @@ async def handle_call_tool(
         if name in WRITE_TOOLS:
             is_error = isinstance(result, types.CallToolResult) and result.isError
             if not is_error:
-                _record_write()
+                _record_write(client_id)
         return result
 
     except Exception as e:

--- a/simplenote_mcp/server/tool_handlers.py
+++ b/simplenote_mcp/server/tool_handlers.py
@@ -53,6 +53,7 @@ from .utils.common import (
 from .vault import (
     VAULT_TAG,
     VaultDecryptionError,
+    VaultKeyCorruptedError,
     VaultKeyUnavailableError,
     decrypt_content,
     encrypt_content,
@@ -103,19 +104,22 @@ class ToolHandlerBase(ABC):
         self.note_cache = note_cache
 
     @abstractmethod
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle the tool call with the given arguments.
 
         Args:
             arguments: Tool arguments
 
         Returns:
-            List of text content responses
+            A list of text content on success, or a CallToolResult with
+            isError=True (via _format_error_response) on failure.
         """
 
     def _format_error_response(
         self, error: Exception, operation: str, context: dict[str, Any] | None = None
-    ) -> list[types.TextContent]:
+    ) -> types.CallToolResult:
         """Format an error into a consistent JSON response.
 
         Args:
@@ -124,7 +128,9 @@ class ToolHandlerBase(ABC):
             context: Optional context information (note_id, query, etc.)
 
         Returns:
-            List containing formatted error response
+            A CallToolResult with isError=True so the MCP protocol layer
+            (and callers) can distinguish this from a successful response
+            without parsing the JSON payload.
         """
         if isinstance(error, ServerError):
             error_dict = error.to_dict()
@@ -139,7 +145,10 @@ class ToolHandlerBase(ABC):
         if context:
             error_dict["error"]["context"] = context
 
-        return [types.TextContent(type="text", text=json.dumps(error_dict))]
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=json.dumps(error_dict))],
+            isError=True,
+        )
 
     def _get_note_from_cache_or_api(self, note_id: str) -> dict[str, Any]:
         """Get a note from cache first, then API if not found.
@@ -200,13 +209,21 @@ class ToolHandlerBase(ABC):
         into a structured, actionable ConfigurationError.
 
         Raises:
-            ConfigurationError: no key is available (see VaultKeyUnavailableError).
+            ConfigurationError: no key is available (see VaultKeyUnavailableError),
+                or an existing key is corrupted/wrong-length (see
+                VaultKeyCorruptedError) — surfaced clearly rather than
+                silently generating a replacement that would orphan any
+                already-encrypted notes.
         """
         try:
             return get_or_create_vault_key()
         except VaultKeyUnavailableError as e:
             raise ConfigurationError(
                 str(e), subcategory="vault_key_unavailable", recoverable=True
+            ) from e
+        except VaultKeyCorruptedError as e:
+            raise ConfigurationError(
+                str(e), subcategory="vault_key_corrupted", recoverable=False
             ) from e
 
     def _decrypt_for_read(self, content: str) -> tuple[str | None, bool, bool]:
@@ -222,10 +239,22 @@ class ToolHandlerBase(ABC):
             content unchanged when not encrypted; the decrypted plaintext
             when encrypted and a working key is available; None when
             encrypted but not decryptable (no key, or the wrong key).
+
+        Raises:
+            ConfigurationError: the key file/keychain entry exists but is
+                corrupted — surfaced rather than silently reported as
+                "not decryptable", since that would look identical to
+                "no key configured yet" and hide a real problem.
         """
         if not is_encrypted(content):
             return content, False, True
-        if not has_vault_key():
+        try:
+            key_available = has_vault_key()
+        except VaultKeyCorruptedError as e:
+            raise ConfigurationError(
+                str(e), subcategory="vault_key_corrupted", recoverable=False
+            ) from e
+        if not key_available:
             return None, True, False
         try:
             return decrypt_content(content, self._resolve_vault_key()), True, True
@@ -282,7 +311,9 @@ class CreateNoteHandler(ToolHandlerBase):
 
     @validate_tool_security("create_note")
     @with_input_validation(validate_content_required)
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle create_note tool call."""
         content = arguments.get("content", "")
         tags_input = arguments.get("tags", "")
@@ -348,7 +379,9 @@ class UpdateNoteHandler(ToolHandlerBase):
 
     @validate_tool_security("update_note")
     @with_input_validation(validate_note_id_required, validate_content_required)
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle update_note tool call."""
         note_id = arguments.get("note_id", "")
         content = arguments.get("content", "")
@@ -467,7 +500,9 @@ class DeleteNoteHandler(ToolHandlerBase):
 
     @validate_tool_security("delete_note")
     @with_input_validation(validate_note_id_required)
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle delete_note tool call."""
         note_id = arguments.get("note_id", "")
 
@@ -509,7 +544,9 @@ class GetNoteHandler(ToolHandlerBase):
 
     @validate_tool_security("get_note")
     @with_input_validation(validate_note_id_required)
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle get_note tool call."""
         note_id = arguments.get("note_id", "")
 
@@ -564,7 +601,9 @@ class SearchNotesHandler(ToolHandlerBase):
 
     @validate_tool_security("search_notes")
     @with_input_validation(validate_query_required)
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle search_notes tool call."""
         query = arguments.get("query", "")
         if not query:
@@ -726,7 +765,7 @@ class SearchNotesHandler(ToolHandlerBase):
                 sort_direction,
             )
 
-    def _handle_search_error(self, e: Exception, query: str) -> list[types.TextContent]:
+    def _handle_search_error(self, e: Exception, query: str) -> types.CallToolResult:
         """Handle search errors and return appropriate response."""
         return self._format_error_response(
             e, f"searching notes for '{query}'", {"query": query}
@@ -967,7 +1006,9 @@ class AddTagsHandler(TagOperationHandler):
 
     @validate_tool_security("add_tags")
     @with_input_validation(validate_note_id_required, validate_tags_required)
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle add_tags tool call."""
         note_id = arguments.get("note_id", "")
         tags_input = arguments.get("tags", "")
@@ -1062,7 +1103,9 @@ class RemoveTagsHandler(TagOperationHandler):
 
     @validate_tool_security("remove_tags")
     @with_input_validation(validate_note_id_required, validate_tags_required)
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle remove_tags tool call."""
         note_id = arguments.get("note_id", "")
         tags_input = arguments.get("tags", "")
@@ -1178,7 +1221,9 @@ class ReplaceTagsHandler(TagOperationHandler):
 
     @validate_tool_security("replace_tags")
     @with_input_validation(validate_note_id_required, validate_tags_required)
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle replace_tags tool call."""
         note_id = arguments.get("note_id", "")
         tags_input = arguments.get("tags", "")
@@ -1249,7 +1294,9 @@ class FindAndMergeDuplicatesHandler(ToolHandlerBase):
     """Handler for find_and_merge_duplicates tool."""
 
     @validate_tool_security("find_and_merge_duplicates")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle find_and_merge_duplicates tool call.
 
         Finds duplicate notes and optionally merges them.
@@ -1486,7 +1533,9 @@ class ExportNotesHandler(ToolHandlerBase):
     """Handler for export_notes tool."""
 
     @validate_tool_security("export_notes")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle export_notes tool call.
 
         Exports one or more notes to Markdown or JSON format.
@@ -1568,7 +1617,9 @@ class AddTextHandler(ToolHandlerBase):
     """Handler for add_text tool — non-destructive append/prepend to a note."""
 
     @validate_tool_security("add_text")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle add_text tool call."""
         from .errors import ValidationError
 
@@ -1635,7 +1686,9 @@ class GetNoteVersionsHandler(ToolHandlerBase):
     PREVIEW_MAX_LENGTH = 200
 
     @validate_tool_security("get_note_versions")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle get_note_versions tool call."""
         from .errors import ValidationError
 
@@ -1704,7 +1757,9 @@ class RestoreVersionHandler(ToolHandlerBase):
     """Handler for restore_version tool — roll back a note to an earlier version."""
 
     @validate_tool_security("restore_version")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle restore_version tool call."""
         from .errors import ValidationError
 
@@ -1796,7 +1851,9 @@ class ReplaceSectionHandler(ToolHandlerBase):
     """Handler for replace_section tool — surgical Markdown section replacement."""
 
     @validate_tool_security("replace_section")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle replace_section tool call."""
         from .errors import ValidationError
 
@@ -1888,7 +1945,9 @@ class AppendToDailyNoteHandler(ToolHandlerBase):
     """Handler for append_to_daily_note tool — timestamped journaling."""
 
     @validate_tool_security("append_to_daily_note")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle append_to_daily_note tool call."""
         from .errors import ValidationError
 
@@ -1979,7 +2038,9 @@ class GetOrCreateNoteHandler(ToolHandlerBase):
     """Handler for get_or_create_note tool — atomic find-or-create."""
 
     @validate_tool_security("get_or_create_note")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle get_or_create_note tool call."""
         from .errors import ValidationError
 
@@ -2068,7 +2129,9 @@ class RenameTagHandler(ToolHandlerBase):
     """Handler for rename_tag tool — atomically rename a tag across all notes."""
 
     @validate_tool_security("rename_tag")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle rename_tag tool call."""
         from .errors import ValidationError
 
@@ -2162,7 +2225,9 @@ class ListTagsHandler(ToolHandlerBase):
     """Handler for list_tags tool — list all tags with note counts."""
 
     @validate_tool_security("list_tags")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle list_tags tool call."""
         sort_by = arguments.get("sort_by", "alpha")
 
@@ -2206,7 +2271,9 @@ class FindUntaggedNotesHandler(ToolHandlerBase):
     """Handler for find_untagged_notes tool — list notes with no tags."""
 
     @validate_tool_security("find_untagged_notes")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle find_untagged_notes tool call."""
         if self.note_cache is None or not self.note_cache.is_initialized:
             return self._format_error_response(
@@ -2266,7 +2333,9 @@ class BulkTagHandler(ToolHandlerBase):
     VALID_ACTIONS = {"add", "remove", "set"}
 
     @validate_tool_security("bulk_tag")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle bulk_tag tool call."""
         note_ids = arguments.get("note_ids")
         action = arguments.get("action")
@@ -2338,7 +2407,9 @@ class RestoreNoteHandler(ToolHandlerBase):
     """Handler for restore_note tool — un-trash a deleted note."""
 
     @validate_tool_security("restore_note")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle restore_note tool call."""
         note_id = arguments.get("note_id", "")
 
@@ -2401,7 +2472,9 @@ class PublishNoteHandler(ToolHandlerBase):
     """Handler for publish_note tool — publish a note to a public URL."""
 
     @validate_tool_security("publish_note")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle publish_note tool call."""
         note_id = arguments.get("note_id", "")
 
@@ -2451,7 +2524,9 @@ class UnpublishNoteHandler(ToolHandlerBase):
     """Handler for unpublish_note tool — remove a note from public access."""
 
     @validate_tool_security("unpublish_note")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle unpublish_note tool call."""
         note_id = arguments.get("note_id", "")
 
@@ -2511,7 +2586,9 @@ class EncryptNoteHandler(ToolHandlerBase):
     """Handler for encrypt_note tool — Vault-encrypt an existing note's body."""
 
     @validate_tool_security("encrypt_note")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle encrypt_note tool call."""
         note_id = arguments.get("note_id", "")
 
@@ -2577,7 +2654,9 @@ class DecryptNoteHandler(ToolHandlerBase):
     """Handler for decrypt_note tool — reverse encrypt_note."""
 
     @validate_tool_security("decrypt_note")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle decrypt_note tool call."""
         note_id = arguments.get("note_id", "")
 
@@ -2650,7 +2729,9 @@ class DecryptNoteHandler(ToolHandlerBase):
 class VaultStatusHandler(ToolHandlerBase):
     """Handler for vault_status tool — read-only Vault key/encrypted-note status."""
 
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle vault_status tool call."""
         del arguments  # no parameters
 
@@ -2658,17 +2739,28 @@ class VaultStatusHandler(ToolHandlerBase):
         if self.note_cache is not None and self.note_cache.is_initialized:
             encrypted_count = len(self.note_cache._tag_index.get(VAULT_TAG, set()))
 
+        key_available = False
+        key_error: str | None = None
+        try:
+            key_available = has_vault_key()
+        except VaultKeyCorruptedError as e:
+            # A status check must not itself crash on a corrupted key — that
+            # would defeat the point of being able to diagnose it.
+            key_error = str(e)
+
+        status: dict[str, Any] = {
+            "success": True,
+            "key_available": key_available,
+            "key_provider": key_provider_name(),
+            "encrypted_note_count": encrypted_count,
+        }
+        if key_error is not None:
+            status["key_error"] = key_error
+
         return [
             types.TextContent(
                 type="text",
-                text=json.dumps(
-                    {
-                        "success": True,
-                        "key_available": has_vault_key(),
-                        "key_provider": key_provider_name(),
-                        "encrypted_note_count": encrypted_count,
-                    }
-                ),
+                text=json.dumps(status),
             )
         ]
 
@@ -2676,7 +2768,9 @@ class VaultStatusHandler(ToolHandlerBase):
 class GetServerInfoHandler(ToolHandlerBase):
     """Handler for get_server_info tool — returns version, author, and debug info."""
 
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle get_server_info tool call."""
         import platform
         import sys
@@ -2738,7 +2832,9 @@ class PermanentDeleteNoteHandler(ToolHandlerBase):
     """Handler for permanent_delete_note tool — irreversibly destroy a note."""
 
     @validate_tool_security("permanent_delete_note")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle permanent_delete_note tool call.
 
         Args:
@@ -2811,7 +2907,9 @@ class EmptyTrashHandler(ToolHandlerBase):
     """Handler for empty_trash tool — permanently delete all trashed notes."""
 
     @validate_tool_security("empty_trash")
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle empty_trash tool call.
 
         Args:
@@ -2935,7 +3033,9 @@ class EmptyTrashHandler(ToolHandlerBase):
 class ListNotesHandler(ToolHandlerBase):
     """Handler for list_notes tool — browse recent notes, optionally by tag."""
 
-    async def handle(self, arguments: dict[str, Any]) -> list[types.TextContent]:
+    async def handle(
+        self, arguments: dict[str, Any]
+    ) -> list[types.TextContent] | types.CallToolResult:
         """Handle list_notes tool call."""
         tag: str | None = arguments.get("tag")
         limit = min(int(arguments.get("limit", 20)), 100)

--- a/simplenote_mcp/server/vault.py
+++ b/simplenote_mcp/server/vault.py
@@ -50,6 +50,13 @@ class VaultKeyUnavailableError(Exception):
     """Raised when no vault key can be resolved or generated."""
 
 
+class VaultKeyCorruptedError(Exception):
+    """Raised when a vault key file/entry exists but is unreadable,
+    malformed, or the wrong length. Never overwritten automatically —
+    losing this key makes existing encrypted notes permanently unreadable,
+    so a human must resolve it deliberately."""
+
+
 class VaultDecryptionError(Exception):
     """Raised when decryption fails — wrong/missing key, malformed envelope,
     or tampered ciphertext."""
@@ -61,11 +68,42 @@ class VaultDecryptionError(Exception):
 
 
 def _read_key_file(path: str) -> bytes | None:
+    """Read and decode the vault key file.
+
+    Returns None only when the file genuinely doesn't exist yet — safe for
+    the caller to generate and persist a fresh key. Any other failure (I/O
+    error, malformed base64, wrong decoded length) raises
+    VaultKeyCorruptedError instead of returning None, so an existing key is
+    never silently overwritten just because it's temporarily unreadable or
+    corrupt.
+    """
+    p = Path(path)
     try:
-        raw = Path(path).read_text().strip()
-        return base64.b64decode(raw, validate=True) if raw else None
-    except (OSError, binascii.Error, ValueError):
+        raw = p.read_text().strip()
+    except FileNotFoundError:
         return None
+    except OSError as e:
+        raise VaultKeyCorruptedError(
+            f"Vault key file {path} exists but could not be read: {e}"
+        ) from e
+
+    if not raw:
+        raise VaultKeyCorruptedError(f"Vault key file {path} exists but is empty.")
+
+    try:
+        key = base64.b64decode(raw, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise VaultKeyCorruptedError(
+            f"Vault key file {path} does not contain valid base64: {e}"
+        ) from e
+
+    if len(key) != _KEY_LENGTH_BYTES:
+        raise VaultKeyCorruptedError(
+            f"Vault key file {path} contains a {len(key)}-byte key; "
+            f"expected {_KEY_LENGTH_BYTES} bytes (AES-256)."
+        )
+
+    return key
 
 
 def _write_key_file(path: str, key: bytes) -> None:
@@ -80,6 +118,15 @@ def _write_key_file(path: str, key: bytes) -> None:
 
 
 def _read_keyring_key() -> bytes | None:
+    """Read and decode the vault key from the OS keychain.
+
+    Returns None when no entry exists yet, or when the keychain backend
+    itself errors (no backend configured, access denied, etc.) — those
+    look identical to "not provisioned yet" from this library's API, so
+    they're treated as safe-to-generate, matching prior behavior. An entry
+    that *does* exist but is malformed or the wrong length raises
+    VaultKeyCorruptedError instead, so it's never silently replaced.
+    """
     import keyring
     import keyring.errors
 
@@ -90,9 +137,19 @@ def _read_keyring_key() -> bytes | None:
     if not raw:
         return None
     try:
-        return base64.b64decode(raw, validate=True)
-    except (binascii.Error, ValueError):
-        return None
+        key = base64.b64decode(raw, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise VaultKeyCorruptedError(
+            f"Vault key stored in the OS keychain is not valid base64: {e}"
+        ) from e
+
+    if len(key) != _KEY_LENGTH_BYTES:
+        raise VaultKeyCorruptedError(
+            f"Vault key stored in the OS keychain is {len(key)} bytes; "
+            f"expected {_KEY_LENGTH_BYTES} bytes (AES-256)."
+        )
+
+    return key
 
 
 def _write_keyring_key(key: bytes) -> bool:
@@ -120,6 +177,10 @@ def get_or_create_vault_key() -> bytes:
     Raises:
         VaultKeyUnavailableError: no SIMPLENOTE_VAULT_KEY_FILE is set and the
             OS keychain has no backend available to store a new key.
+        VaultKeyCorruptedError: a key file/keychain entry exists but is
+            unreadable, malformed, or the wrong length. Never generates a
+            replacement in this case — that would silently orphan any
+            notes already encrypted with the original key.
     """
     global _cached_key
     if _cached_key is not None:
@@ -149,7 +210,12 @@ def get_or_create_vault_key() -> bytes:
 
 
 def has_vault_key() -> bool:
-    """Return True if a vault key is available, without generating a new one."""
+    """Return True if a vault key is available, without generating a new one.
+
+    Raises:
+        VaultKeyCorruptedError: a key file/keychain entry exists but is
+            unreadable, malformed, or the wrong length.
+    """
     if _cached_key is not None:
         return True
     key_file = os.environ.get("SIMPLENOTE_VAULT_KEY_FILE")

--- a/simplenote_mcp/tests/conftest.py
+++ b/simplenote_mcp/tests/conftest.py
@@ -255,3 +255,30 @@ def event_loop():
     asyncio.set_event_loop(loop)
     yield loop
     loop.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_global_singletons():
+    """Reset process-global singletons that tests in this directory read
+    and mutate via module-level convenience functions (metrics collector,
+    security validator's attempt-tracking dicts).
+
+    Without this, results depend on pytest's collection/execution order —
+    counters accumulate across every test that happens to run first in the
+    same process, rather than each test starting from a clean baseline.
+    pytest-randomly (enabled project-wide) makes that order non-deterministic
+    run to run.
+
+    MetricsCollector implements the singleton pattern via __new__/_instance,
+    so constructing "a new one" just returns the same object with the same
+    accumulated state — __init__ even short-circuits on self._initialized.
+    The only way to actually reset it is to replace its .metrics attribute
+    directly on the existing instance.
+    """
+    import simplenote_mcp.server.monitoring.metrics as metrics_module
+    import simplenote_mcp.server.security as security_module
+
+    metrics_module._metrics_collector.metrics = metrics_module.PerformanceMetrics()
+    security_module.security_validator.failed_validation_attempts.clear()
+    security_module.security_validator.rate_limit_attempts.clear()
+    yield

--- a/simplenote_mcp/tests/pagination_and_cache_diagnostic.py
+++ b/simplenote_mcp/tests/pagination_and_cache_diagnostic.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python
 """
-Tests for pagination features and cache performance.
+Manual diagnostic script for pagination features and cache performance.
 
-This test suite verifies the pagination functionality and measures
-the performance improvements from the optimized cache implementation.
+Requires a real Simplenote account (SIMPLENOTE_EMAIL/SIMPLENOTE_PASSWORD) —
+run directly (`python pagination_and_cache_diagnostic.py`) or via
+run_tests.py's PERFORMANCE category. Not a pytest test module: its
+functions take a `cache: NoteCache` parameter with no matching fixture, so
+it was previously being collected by bare `pytest` under its old
+`test_pagination_and_cache.py` name and either erroring (fixture not
+found) or vacuously "passing" (an unawaited coroutine raises nothing) —
+neither of which ever exercised the code. Renamed to opt out of pytest's
+`test_*.py` collection entirely.
 """
 
 import asyncio

--- a/simplenote_mcp/tests/run_tests.py
+++ b/simplenote_mcp/tests/run_tests.py
@@ -71,7 +71,7 @@ def discover_tests(category: TestCategory = TestCategory.ALL) -> list[str]:
         TestCategory.UNIT: ["test_*py"],
         TestCategory.INTEGRATION: ["test_integration_*py"],
         TestCategory.PERFORMANCE: [
-            "test_pagination_and_cache.py",
+            "pagination_and_cache_diagnostic.py",
             "benchmark_cache.py",
             "test_search.py",
         ],
@@ -84,7 +84,7 @@ def discover_tests(category: TestCategory = TestCategory.ALL) -> list[str]:
         exclude = {str(p) for p in tests_dir.glob("test_integration_*.py")}
         exclude.update(
             {
-                str(tests_dir / "test_pagination_and_cache.py"),
+                str(tests_dir / "pagination_and_cache_diagnostic.py"),
                 str(tests_dir / "benchmark_cache.py"),
             }
         )

--- a/simplenote_mcp/tests/test_compat.py
+++ b/simplenote_mcp/tests/test_compat.py
@@ -159,23 +159,13 @@ class TestOtherCompat:
     """Test other compatibility features."""
 
     def test_path_module_functionality(self):
-        """Test that the correct Path implementation is used based on Python version."""
-        # This just verifies that the Path class has the expected functionality
-        if sys.version_info >= (3, 13):
-            # Python 3.13+: We should be using our custom Path implementation
-            import inspect
+        """compat.Path is a direct re-export of pathlib.Path on every
+        supported Python version — there is no custom implementation to
+        version-branch on (removed since this test was first written, once
+        pathlib itself covered what it used to work around)."""
+        import pathlib
 
-            path_module = inspect.getmodule(Path)
-            assert "compat" in str(path_module), (
-                "Path should come from our compat module in Python 3.13+"
-            )
-        else:
-            # Python < 3.13: We should be using pathlib.Path
-            import pathlib
-
-            assert Path == pathlib.Path, (
-                "Path should be identical to pathlib.Path in Python < 3.13"
-            )
+        assert Path is pathlib.Path
 
 
 if __name__ == "__main__":

--- a/simplenote_mcp/tests/test_error_categorization.py
+++ b/simplenote_mcp/tests/test_error_categorization.py
@@ -225,8 +225,8 @@ class TestErrorCategorization:
             error = handle_exception(e)
 
         assert isinstance(error, ValidationError), "Should be a ValidationError"
-        assert error.subcategory == "required", (
-            "Subcategory should be 'required' based on error message"
+        assert error.subcategory == "required_field", (
+            "Subcategory should be 'required_field' based on error message"
         )
 
         # Test network error detection
@@ -236,7 +236,9 @@ class TestErrorCategorization:
             error = handle_exception(e)
 
         assert isinstance(error, NetworkError), "Should be a NetworkError"
-        assert error.subcategory == "connection", "Subcategory should be 'connection'"
+        assert error.subcategory == "connection_failed", (
+            "Subcategory should be 'connection_failed'"
+        )
 
     def test_error_codes(self):
         """Test error code generation and parsing."""

--- a/tests/test_auth_robustness.py
+++ b/tests/test_auth_robustness.py
@@ -17,6 +17,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import mcp.types as types
 import pytest
 
 from simplenote_mcp.server.errors import AuthenticationError, ResourceNotFoundError
@@ -220,8 +221,9 @@ class TestGetNoteVersionsHandler:
 
         result = await handler.handle({"note_id": "some-id"})
 
-        assert result
-        payload = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        payload = json.loads(result.content[0].text)
         assert payload.get("success") is False
         # Must NOT have called sn.get_note (which would TypeError)
         sn.get_note.assert_not_called()

--- a/tests/test_client_scoped_limits.py
+++ b/tests/test_client_scoped_limits.py
@@ -1,0 +1,109 @@
+"""Tests for per-client identity resolution and the per-client write budget
+added to server.py: _resolve_client_id(), _check_write_budget(),
+_record_write(). Covers both the stdio fallback and HTTP-transport identity
+derived from mcp.server.lowlevel.server's request_ctx contextvar.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+import simplenote_mcp.server.server as srv
+from simplenote_mcp.server.errors import ValidationError
+
+
+def _fake_request_context(request):
+    """Build a minimal object with a `.request` attribute, matching the
+    shape server.request_context returns (only `.request` is read)."""
+    return SimpleNamespace(request=request)
+
+
+class TestResolveClientId:
+    def test_no_active_request_context_is_stdio_local(self):
+        # No request_ctx contextvar set at all — matches a direct call
+        # outside of any MCP request (e.g. process startup).
+        assert srv._resolve_client_id() == "stdio-local"
+
+    def test_stdio_request_context_with_no_request_is_stdio_local(self):
+        fake_ctx = _fake_request_context(request=None)
+        with patch.object(
+            type(srv.server),
+            "request_context",
+            new_callable=PropertyMock,
+            return_value=fake_ctx,
+        ):
+            assert srv._resolve_client_id() == "stdio-local"
+
+    def test_http_request_uses_peer_source_ip(self):
+        fake_request = SimpleNamespace(client=SimpleNamespace(host="203.0.113.5"))
+        fake_ctx = _fake_request_context(request=fake_request)
+        with patch.object(
+            type(srv.server),
+            "request_context",
+            new_callable=PropertyMock,
+            return_value=fake_ctx,
+        ):
+            assert srv._resolve_client_id() == "http:203.0.113.5"
+
+    def test_http_request_without_client_attr_is_unknown(self):
+        fake_request = SimpleNamespace(client=None)
+        fake_ctx = _fake_request_context(request=fake_request)
+        with patch.object(
+            type(srv.server),
+            "request_context",
+            new_callable=PropertyMock,
+            return_value=fake_ctx,
+        ):
+            assert srv._resolve_client_id() == "http:unknown"
+
+    def test_different_peers_get_different_identifiers(self):
+        for host in ("10.0.0.1", "10.0.0.2"):
+            fake_request = SimpleNamespace(client=SimpleNamespace(host=host))
+            fake_ctx = _fake_request_context(request=fake_request)
+            with patch.object(
+                type(srv.server),
+                "request_context",
+                new_callable=PropertyMock,
+                return_value=fake_ctx,
+            ):
+                assert srv._resolve_client_id() == f"http:{host}"
+
+
+class TestPerClientWriteBudget:
+    @pytest.fixture(autouse=True)
+    def _clean_budget_state(self):
+        srv._write_timestamps.clear()
+        yield
+        srv._write_timestamps.clear()
+
+    def _config(self, max_writes=3, window=60):
+        config = MagicMock()
+        config.write_budget_max = max_writes
+        config.write_budget_window_seconds = window
+        return config
+
+    def test_budget_exhaustion_is_scoped_to_one_client(self):
+        config = self._config(max_writes=2)
+        with patch("simplenote_mcp.server.server.get_config", return_value=config):
+            srv._check_write_budget("client-a")
+            srv._record_write("client-a")
+            srv._check_write_budget("client-a")
+            srv._record_write("client-a")
+
+            # client-a is now at its limit (2/2) — the third check must fail.
+            with pytest.raises(ValidationError, match="Write budget exhausted"):
+                srv._check_write_budget("client-a")
+
+            # client-b has never written — its own budget is untouched.
+            srv._check_write_budget("client-b")  # must not raise
+
+    def test_recording_a_write_only_affects_that_clients_bucket(self):
+        config = self._config(max_writes=100)
+        with patch("simplenote_mcp.server.server.get_config", return_value=config):
+            srv._record_write("client-a")
+            srv._record_write("client-a")
+            srv._record_write("client-b")
+
+        assert len(srv._write_timestamps["client-a"]) == 2
+        assert len(srv._write_timestamps["client-b"]) == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -710,3 +710,48 @@ class TestConfigValidateRateLimiting:
             config = Config()
             with pytest.raises(ValueError, match="HTTP_METRICS_PATH must start with"):
                 config.validate()
+
+
+class TestMcpHttpAuthConfig:
+    """Tests for MCP_HTTP_AUTH_TOKEN/ALLOWED_HOSTS/ALLOWED_ORIGINS parsing."""
+
+    BASE_ENV = {
+        "SIMPLENOTE_EMAIL": "test@example.com",
+        "SIMPLENOTE_PASSWORD": "test_password",  # noqa: S105
+    }
+
+    def test_defaults_are_empty(self):
+        with patch.dict(os.environ, self.BASE_ENV, clear=True):
+            config = Config()
+            assert config.mcp_http_auth_token is None
+            assert config.mcp_http_allowed_hosts == []
+            assert config.mcp_http_allowed_origins == []
+
+    def test_empty_token_env_var_treated_as_unset(self):
+        with patch.dict(
+            os.environ, {**self.BASE_ENV, "MCP_HTTP_AUTH_TOKEN": ""}, clear=True
+        ):
+            config = Config()
+            assert config.mcp_http_auth_token is None
+
+    def test_token_and_allowlists_parsed(self):
+        with patch.dict(
+            os.environ,
+            {
+                **self.BASE_ENV,
+                "MCP_HTTP_AUTH_TOKEN": "s3cret-token",  # noqa: S105
+                "MCP_HTTP_ALLOWED_HOSTS": "example.com, api.example.com:8443 ,",
+                "MCP_HTTP_ALLOWED_ORIGINS": "https://example.com,https://app.example.com",
+            },
+            clear=True,
+        ):
+            config = Config()
+            assert config.mcp_http_auth_token == "s3cret-token"  # noqa: S105
+            assert config.mcp_http_allowed_hosts == [
+                "example.com",
+                "api.example.com:8443",
+            ]
+            assert config.mcp_http_allowed_origins == [
+                "https://example.com",
+                "https://app.example.com",
+            ]

--- a/tests/test_end_to_end_scenarios.py
+++ b/tests/test_end_to_end_scenarios.py
@@ -5,6 +5,7 @@ import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import mcp.types as types
 import pytest
 
 from simplenote_mcp.server.errors import ResourceNotFoundError
@@ -385,8 +386,9 @@ class TestEndToEndScenarios:
         )
 
         # Check that we got an error response
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["error"] is not None  # Should contain error information
 
         # Scenario 2: Recovery after network failure
@@ -431,11 +433,15 @@ class TestEndToEndScenarios:
                 "create_note", {"content": content, "tags": tags}
             )
 
-            response = json.loads(result[0].text)
-            if response["success"]:
-                success_count += 1
-            else:
+            if isinstance(result, types.CallToolResult):
+                assert result.isError is True
                 failure_count += 1
+            else:
+                response = json.loads(result[0].text)
+                if response["success"]:
+                    success_count += 1
+                else:
+                    failure_count += 1
 
         # Should have partial success
         assert success_count >= 1

--- a/tests/test_http_endpoints.py
+++ b/tests/test_http_endpoints.py
@@ -255,6 +255,96 @@ class TestHTTPEndpointsHandler:
         assert isinstance(HTTPEndpointsHandler.metrics_collector, MetricsCollector)
 
 
+class TestHealthEndpointStatusCode:
+    """/health must only fail (503) on a genuine 'unhealthy' check.
+
+    Regression test: it used to fail on 'degraded' too — e.g. a low cache
+    hit rate, which is completely normal right after startup or during a
+    quiet period, not a sign the process is actually broken. Wired to a
+    Docker HEALTHCHECK or a Kubernetes livenessProbe (both added as part of
+    the 2026-07-13 audit remediation), that caused spurious restarts.
+    Uses a real running HTTPEndpointsServer + real HTTP requests rather
+    than mocking BaseHTTPRequestHandler internals, to exercise the exact
+    code path a real probe hits.
+    """
+
+    def setup_method(self):
+        HTTPEndpointsHandler.health_status = HealthStatus()
+        HTTPEndpointsHandler.readiness_checker = ReadinessChecker()
+        HTTPEndpointsHandler.metrics_collector = MetricsCollector()
+
+    def _start_server(self, mock_config):
+        mock_config.return_value = MagicMock(
+            enable_http_endpoint=True,
+            http_host="127.0.0.1",
+            http_port=0,  # OS-assigned free port
+            http_health_path="/health",
+            http_ready_path="/ready",
+            http_metrics_path="/metrics",
+            cache_health_checks=False,  # isolate from real cache state
+        )
+        server = HTTPEndpointsServer()
+        server.start()
+        time.sleep(0.1)  # let the background thread bind the socket
+        port = server.server.server_port
+        return server, port
+
+    @patch("simplenote_mcp.server.http_endpoints.get_config")
+    @patch("simplenote_mcp.server.http_endpoints.get_memory_metrics")
+    def test_degraded_check_returns_200(self, mock_memory, mock_config):
+        import urllib.request
+
+        mock_memory.return_value = {"memory_usage": 0}
+        server, port = self._start_server(mock_config)
+        # Simulate a degraded (not unhealthy) subsystem, e.g. a low cache
+        # hit rate — must not fail the probe.
+        HTTPEndpointsHandler.health_status.add_check(
+            "cache", "degraded", "Low cache hit rate: 0.0%"
+        )
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/health", timeout=5
+            ) as response:
+                assert response.status == 200
+        finally:
+            server.stop()
+
+    @patch("simplenote_mcp.server.http_endpoints.get_config")
+    @patch("simplenote_mcp.server.http_endpoints.get_memory_metrics")
+    def test_unhealthy_check_returns_503(self, mock_memory, mock_config):
+        import urllib.error
+        import urllib.request
+
+        mock_memory.return_value = {"memory_usage": 0}
+        server, port = self._start_server(mock_config)
+        HTTPEndpointsHandler.health_status.add_check(
+            "dependency", "unhealthy", "A required subsystem failed"
+        )
+        try:
+            try:
+                urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=5)
+                raise AssertionError("expected HTTPError for a 503 response")
+            except urllib.error.HTTPError as e:
+                assert e.code == 503
+        finally:
+            server.stop()
+
+    @patch("simplenote_mcp.server.http_endpoints.get_config")
+    @patch("simplenote_mcp.server.http_endpoints.get_memory_metrics")
+    def test_all_healthy_returns_200(self, mock_memory, mock_config):
+        import urllib.request
+
+        mock_memory.return_value = {"memory_usage": 0}
+        server, port = self._start_server(mock_config)
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/health", timeout=5
+            ) as response:
+                assert response.status == 200
+        finally:
+            server.stop()
+
+
 class TestHTTPEndpointsServer:
     """Tests for HTTPEndpointsServer class."""
 

--- a/tests/test_http_transport_security.py
+++ b/tests/test_http_transport_security.py
@@ -1,0 +1,165 @@
+"""Tests for the MCP HTTP transport security controls added in server.py:
+loopback detection, the bearer-token check, the DNS-rebinding-protection
+TransportSecuritySettings builder, and run_http()'s fail-closed startup
+guard for non-loopback binds without a configured token.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mcp.server.transport_security import TransportSecuritySettings
+
+import simplenote_mcp.server.server as srv
+from simplenote_mcp.server.errors import ConfigurationError
+
+
+class TestIsLoopbackHost:
+    @pytest.mark.parametrize(
+        "host,expected",
+        [
+            ("127.0.0.1", True),
+            ("localhost", True),
+            ("::1", True),
+            ("0.0.0.0", False),  # noqa: S104
+            ("192.168.1.5", False),
+            ("example.com", False),
+        ],
+    )
+    def test_loopback_detection(self, host, expected):
+        assert srv._is_loopback_host(host) is expected
+
+
+class TestBearerTokenValid:
+    def _scope(self, auth_header: bytes | None) -> dict:
+        headers = [] if auth_header is None else [(b"authorization", auth_header)]
+        return {"headers": headers}
+
+    def test_correct_token_is_valid(self):
+        scope = self._scope(b"Bearer s3cret")
+        assert srv._bearer_token_valid(scope, "s3cret") is True
+
+    def test_wrong_token_is_invalid(self):
+        scope = self._scope(b"Bearer wrong-token")
+        assert srv._bearer_token_valid(scope, "s3cret") is False
+
+    def test_missing_header_is_invalid(self):
+        scope = self._scope(None)
+        assert srv._bearer_token_valid(scope, "s3cret") is False
+
+    def test_non_bearer_scheme_is_invalid(self):
+        scope = self._scope(b"Basic dXNlcjpwYXNz")
+        assert srv._bearer_token_valid(scope, "s3cret") is False
+
+    def test_empty_headers_list_is_invalid(self):
+        assert srv._bearer_token_valid({"headers": []}, "s3cret") is False
+
+    def test_no_headers_key_is_invalid(self):
+        assert srv._bearer_token_valid({}, "s3cret") is False
+
+
+class TestBuildHttpSecuritySettings:
+    def _config(self, allowed_hosts=None, allowed_origins=None):
+        config = MagicMock()
+        config.mcp_http_allowed_hosts = allowed_hosts or []
+        config.mcp_http_allowed_origins = allowed_origins or []
+        return config
+
+    def test_explicit_allowed_hosts_enables_protection(self):
+        config = self._config(allowed_hosts=["example.com"])
+        settings = srv._build_http_security_settings(config, host="0.0.0.0")  # noqa: S104
+        assert isinstance(settings, TransportSecuritySettings)
+        assert settings.enable_dns_rebinding_protection is True
+        assert settings.allowed_hosts == ["example.com"]
+
+    def test_loopback_host_gets_safe_default_allowlist(self):
+        config = self._config()
+        settings = srv._build_http_security_settings(config, host="127.0.0.1")
+        assert settings.enable_dns_rebinding_protection is True
+        assert "127.0.0.1:*" in settings.allowed_hosts
+        assert "localhost:*" in settings.allowed_hosts
+
+    def test_non_loopback_without_allowlist_disables_protection_with_warning(
+        self, caplog
+    ):
+        import logging
+
+        config = self._config()
+        with caplog.at_level(logging.WARNING, logger="simplenote_mcp"):
+            settings = srv._build_http_security_settings(config, host="0.0.0.0")  # noqa: S104
+        assert settings.enable_dns_rebinding_protection is False
+        assert any(
+            "DNS rebinding protection disabled" in r.message for r in caplog.records
+        )
+
+
+class TestRunHttpFailClosedGuard:
+    """run_http() must refuse to start on a non-loopback host without a
+    configured bearer token, and must not do so for loopback binds or
+    non-loopback binds that do have a token configured.
+    """
+
+    def _config(self, token=None):
+        config = MagicMock()
+        config.mcp_http_auth_token = token
+        config.mcp_http_allowed_hosts = []
+        config.mcp_http_allowed_origins = []
+        return config
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_without_token_raises_before_any_transport_setup(self):
+        config = self._config(token=None)
+        unreachable_transport = MagicMock(
+            side_effect=AssertionError(
+                "transport must not be constructed when the guard rejects startup"
+            )
+        )
+        with (
+            patch("simplenote_mcp.server.server.get_config", return_value=config),
+            patch(
+                "mcp.server.streamable_http.StreamableHTTPServerTransport",
+                unreachable_transport,
+            ),
+            pytest.raises(ConfigurationError, match="MCP_HTTP_AUTH_TOKEN"),
+        ):
+            await srv.run_http(host="0.0.0.0", port=8000, path="/mcp")  # noqa: S104
+
+    class _PastGuardSentinel(Exception):
+        """Raised by the fake transport's connect() to prove control flow
+        reached transport construction — i.e. the guard did not block it."""
+
+    class _FakeConnectCM:
+        async def __aenter__(self):
+            raise TestRunHttpFailClosedGuard._PastGuardSentinel
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+    class _FakeTransport:
+        def connect(self):
+            return TestRunHttpFailClosedGuard._FakeConnectCM()
+
+    @pytest.mark.asyncio
+    async def test_loopback_without_token_passes_the_guard(self):
+        config = self._config(token=None)
+        with (
+            patch("simplenote_mcp.server.server.get_config", return_value=config),
+            patch(
+                "mcp.server.streamable_http.StreamableHTTPServerTransport",
+                return_value=self._FakeTransport(),
+            ),
+            pytest.raises(self._PastGuardSentinel),
+        ):
+            await srv.run_http(host="127.0.0.1", port=8000, path="/mcp")
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_with_token_passes_the_guard(self):
+        config = self._config(token="s3cret")  # noqa: S106
+        with (
+            patch("simplenote_mcp.server.server.get_config", return_value=config),
+            patch(
+                "mcp.server.streamable_http.StreamableHTTPServerTransport",
+                return_value=self._FakeTransport(),
+            ),
+            pytest.raises(self._PastGuardSentinel),
+        ):
+            await srv.run_http(host="0.0.0.0", port=8000, path="/mcp")  # noqa: S104

--- a/tests/test_load_stress.py
+++ b/tests/test_load_stress.py
@@ -10,6 +10,7 @@ import statistics
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import mcp.types as types
 import pytest
 
 
@@ -224,6 +225,13 @@ class TestStressTesting:
         mock_client = MagicMock()
         mock_cache = MagicMock()
         mock_cache._notes = {}
+        # Cache is empty/uninitialized so lookups fall through to the API mock
+        # below. An unconfigured MagicMock().is_initialized is truthy and
+        # MagicMock().get_note(...) returns a non-dict MagicMock rather than
+        # None/raising, so without this the handler would take the cache
+        # branch and treat every lookup as a hard failure (non-dict "note"),
+        # never reaching the API mock at all.
+        mock_cache.is_initialized = False
 
         mock_client.get_note = MagicMock(
             side_effect=lambda nid: ({"key": nid, "content": "Test"}, 0)
@@ -376,11 +384,15 @@ class TestStressTesting:
                     }
                 )
                 total_processed += 1
-                result_data = json.loads(result[0].text)
-                if result_data.get("success") or "key" in result_data:
-                    success_count += 1
-                else:
+                if isinstance(result, types.CallToolResult):
+                    assert result.isError is True
                     error_count += 1
+                else:
+                    result_data = json.loads(result[0].text)
+                    if result_data.get("success") or "key" in result_data:
+                        success_count += 1
+                    else:
+                        error_count += 1
             except Exception:
                 error_count += 1
                 total_processed += 1

--- a/tests/test_note_creation.py
+++ b/tests/test_note_creation.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import mcp.types as types
 import pytest
 
 from simplenote_mcp.server.cache import NoteCache
@@ -263,7 +264,9 @@ async def test_create_note_error_handling(mock_simplenote_client):
             "create_note", {"content": "This should fail"}
         )
 
-        result_data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        result_data = json.loads(result.content[0].text)
 
         assert "error" in result_data
         assert result_data["error"]["type"] == "network"

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -212,18 +212,50 @@ class TestSecurityValidator:
             self.validator.validate_pagination_params(10, "invalid")
 
     def test_validate_date_range_valid(self):
-        """Test validation of valid date ranges."""
-        # Valid ISO format dates
+        """Test validation of valid date ranges.
+
+        validate_date_range returns the *original* value unchanged (not a
+        parsed datetime) — the search handler's own date parser is the
+        single place that converts strings to datetimes. This method only
+        checks that each value is parseable and the range makes sense.
+        """
+        # Valid ISO format dates — original strings come back unchanged
         from_date, to_date = self.validator.validate_date_range(
             "2023-01-01T00:00:00", "2023-12-31T23:59:59"
         )
-        assert isinstance(from_date, datetime)
-        assert isinstance(to_date, datetime)
+        assert from_date == "2023-01-01T00:00:00"
+        assert to_date == "2023-12-31T23:59:59"
 
         # None values
         from_date, to_date = self.validator.validate_date_range(None, None)
         assert from_date is None
         assert to_date is None
+
+        # datetime objects pass through unchanged too
+        dt_from = datetime(2023, 1, 1)
+        dt_to = datetime(2023, 12, 31)
+        from_date, to_date = self.validator.validate_date_range(dt_from, dt_to)
+        assert from_date is dt_from
+        assert to_date is dt_to
+
+    def test_validate_date_range_natural_language(self):
+        """Every natural-language alias advertised in the search_notes tool
+        schema must survive validation unchanged, both underscored (as
+        advertised) and spaced.
+        """
+        for alias in (
+            "today",
+            "yesterday",
+            "last_week",
+            "last_month",
+            "last_year",
+            "3_days_ago",
+            "2_weeks_ago",
+            "last_monday",
+        ):
+            from_date, to_date = self.validator.validate_date_range(alias, None)
+            assert from_date == alias, f"{alias!r} should pass through unchanged"
+            assert to_date is None
 
     def test_validate_date_range_invalid(self):
         """Test validation fails for invalid date ranges."""

--- a/tests/test_server_advanced.py
+++ b/tests/test_server_advanced.py
@@ -540,7 +540,7 @@ class TestResourceManagement:
             # handle_call_tool catches exceptions and returns error response
             result = await handle_call_tool("create_note", {"content": "test"})
 
-            assert isinstance(result, list)
-            assert len(result) == 1
-            error_data = json.loads(result[0].text)
+            assert isinstance(result, types.CallToolResult)
+            assert result.isError is True
+            error_data = json.loads(result.content[0].text)
             assert "error" in error_data or "message" in error_data

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -764,3 +764,79 @@ class TestErrorCodeHelpers:
         from simplenote_mcp.server.error_codes import get_error_description
 
         assert get_error_description("NONEXISTENT_CODE_XYZ") is None
+
+
+# ---------------------------------------------------------------------------
+# run_main — Config.validate() must run first and fail closed
+# ---------------------------------------------------------------------------
+
+
+class TestRunMainConfigValidation:
+    """run_main() must validate config and fail fast — before PID file
+    creation, signal handler setup, or any attempt to start the server.
+    Regression test: Config.validate() existed but was never called on any
+    production startup path, so invalid config (e.g. missing credentials
+    outside offline mode) only surfaced later, less clearly, deep inside
+    client/cache initialization.
+    """
+
+    def setup_method(self):
+        _reset_note_cache()
+
+    def teardown_method(self):
+        _reset_note_cache()
+
+    def test_invalid_config_exits_before_any_side_effects(self):
+        import simplenote_mcp.server.server as srv
+
+        mock_config = MagicMock()
+        mock_config.log_level = srv.LogLevel.INFO
+        mock_config.validate.side_effect = ValueError(
+            "SIMPLENOTE_EMAIL and SIMPLENOTE_PASSWORD environment variables must be set"
+        )
+
+        with (
+            patch("simplenote_mcp.server.server.get_config", return_value=mock_config),
+            patch("simplenote_mcp.server.server.write_pid_file") as mock_write_pid,
+            patch("simplenote_mcp.server.server.setup_signal_handlers") as mock_signals,
+            patch("simplenote_mcp.server.server.cleanup_pid_file") as mock_cleanup,
+            patch("simplenote_mcp.server.server.asyncio.run") as mock_asyncio_run,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            srv.run_main()
+
+        assert exc_info.value.code == 1
+        mock_config.validate.assert_called_once()
+        mock_write_pid.assert_not_called()
+        mock_signals.assert_not_called()
+        mock_asyncio_run.assert_not_called()
+        mock_cleanup.assert_called_once()
+
+    def test_valid_config_proceeds_past_validation(self):
+        import simplenote_mcp.server.server as srv
+
+        mock_config = MagicMock()
+        mock_config.log_level = srv.LogLevel.INFO
+        mock_config.mcp_transport = "stdio"
+        mock_config.simplenote_email = None
+        mock_config.simplenote_password = None
+        mock_config.validate.return_value = None
+
+        with (
+            patch("simplenote_mcp.server.server.get_config", return_value=mock_config),
+            patch("simplenote_mcp.server.server.write_pid_file") as mock_write_pid,
+            patch("simplenote_mcp.server.server.setup_signal_handlers") as mock_signals,
+            # Mock run() itself too, not just asyncio.run — otherwise the
+            # real `run()` coroutine object still gets constructed (just
+            # never awaited, since asyncio.run is mocked), which logs a
+            # harmless but noisy "coroutine was never awaited" warning.
+            patch("simplenote_mcp.server.server.run", new=AsyncMock()),
+            patch("simplenote_mcp.server.server.asyncio.run") as mock_asyncio_run,
+            patch("simplenote_mcp.server.server.cleanup_pid_file"),
+        ):
+            srv.run_main()
+
+        mock_config.validate.assert_called_once()
+        mock_write_pid.assert_called_once()
+        mock_signals.assert_called_once()
+        mock_asyncio_run.assert_called_once()

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -319,9 +319,9 @@ class TestHandleCallTool:
         ):
             result = await srv.handle_call_tool("nonexistent_tool", {})
 
-        assert isinstance(result, list)
-        assert len(result) == 1
-        payload = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        payload = json.loads(result.content[0].text)
         assert (
             "error" in payload or "message" in payload or "Unknown tool" in str(payload)
         )
@@ -359,9 +359,9 @@ class TestHandleCallTool:
         ):
             result = await srv.handle_call_tool("search_notes", {"query": "test"})
 
-        assert isinstance(result, list)
-        assert len(result) == 1
-        payload = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        payload = json.loads(result.content[0].text)
         # ServerError.to_dict() always has an "error" key
         assert "error" in payload
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -373,6 +373,44 @@ class TestHandleCallTool:
         with pytest.raises(ValidationError):
             await srv.handle_call_tool("create_note", "not-a-dict")  # type: ignore[arg-type]
 
+    @pytest.mark.asyncio
+    async def test_tool_call_does_not_log_plaintext_at_info(self, caplog):
+        """Note content must never appear in INFO-or-above logs.
+
+        Regression test: handle_call_tool used to dump the full, unsanitized
+        arguments dict (including note content) via logger.info() on every
+        call. A sanitized/truncated form at DEBUG is fine and expected.
+        """
+        import logging
+
+        import simplenote_mcp.server.server as srv
+
+        marker = "UNIQUE-PLAINTEXT-MARKER-89f3c2"
+
+        mock_sn = MagicMock()
+        mock_cache = MagicMock()
+        mock_cache.is_initialized = True
+
+        with (
+            patch(
+                "simplenote_mcp.server.server.get_simplenote_client",
+                return_value=mock_sn,
+            ),
+            patch(
+                "simplenote_mcp.server.cache_utils.get_cache_or_create_minimal",
+                return_value=mock_cache,
+            ),
+            caplog.at_level(logging.DEBUG, logger="simplenote_mcp"),
+        ):
+            # Write mode is disabled by default, so this is rejected before
+            # touching the network — the logging call under test runs before
+            # that gate either way, so it still exercises the fixed code path.
+            await srv.handle_call_tool("create_note", {"content": marker})
+
+        for record in caplog.records:
+            if record.levelno >= logging.INFO:
+                assert marker not in record.getMessage()
+
 
 # ---------------------------------------------------------------------------
 # handle_list_prompts

--- a/tests/test_tool_error_scenarios.py
+++ b/tests/test_tool_error_scenarios.py
@@ -7,6 +7,7 @@ the MCP evaluation error handling score (currently 1.4/5).
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import mcp.types as types
 import pytest
 
 from simplenote_mcp.server.errors import (
@@ -62,8 +63,9 @@ class TestCreateNoteHandlerErrors:
 
         result = await handler.handle({"content": "Test note"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert "error" in response
         assert response["error"]["category"] in ["network", "internal"]
@@ -78,8 +80,9 @@ class TestCreateNoteHandlerErrors:
 
         result = await handler.handle({"content": "Test note"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert "error" in response
         assert "message" in response["error"]
@@ -99,8 +102,9 @@ class TestUpdateNoteHandlerErrors:
 
         result = await handler.handle({"note_id": "nonexistent", "content": "Updated"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert response["error"]["category"] == "not_found"
         assert "context" in response["error"]
@@ -120,8 +124,9 @@ class TestUpdateNoteHandlerErrors:
 
         result = await handler.handle({"note_id": "test123", "content": "New content"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert "error" in response
 
@@ -139,8 +144,9 @@ class TestDeleteNoteHandlerErrors:
 
         result = await handler.handle({"note_id": "nonexistent"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert "error" in response
 
@@ -154,8 +160,9 @@ class TestDeleteNoteHandlerErrors:
 
         result = await handler.handle({"note_id": "test123"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert "context" in response["error"]
 
@@ -172,8 +179,9 @@ class TestGetNoteHandlerErrors:
 
         result = await handler.handle({"note_id": "nonexistent"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert response["error"]["category"] == "not_found"
 
@@ -187,8 +195,9 @@ class TestGetNoteHandlerErrors:
 
         result = await handler.handle({"note_id": "test123"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
 
 
@@ -205,8 +214,9 @@ class TestSearchNotesHandlerErrors:
 
         result = await handler.handle({"query": "test"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert "context" in response["error"]
         assert response["error"]["context"]["query"] == "test"
@@ -219,8 +229,9 @@ class TestSearchNotesHandlerErrors:
 
         result = await handler.handle({"query": "test"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
 
 
@@ -238,8 +249,9 @@ class TestTagHandlerErrors:
 
         result = await handler.handle({"note_id": "nonexistent", "tags": "test"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert response["error"]["category"] == "not_found"
 
@@ -255,8 +267,9 @@ class TestTagHandlerErrors:
 
         result = await handler.handle({"note_id": "test123", "tags": "tag1"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
         assert "context" in response["error"]
 
@@ -274,8 +287,9 @@ class TestTagHandlerErrors:
 
         result = await handler.handle({"note_id": "test123", "tags": "new"})
 
-        assert len(result) == 1
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["success"] is False
 
 
@@ -293,7 +307,9 @@ class TestErrorResponseFormat:
 
         result = await handler.handle({"note_id": "test"})
 
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert "success" in response
         assert response["success"] is False
         assert "error" in response
@@ -312,7 +328,9 @@ class TestErrorResponseFormat:
 
         result = await handler.handle({"note_id": "test123", "content": "new content"})
 
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert "context" in response["error"]
         assert "note_id" in response["error"]["context"]
         assert response["error"]["context"]["note_id"] == "test123"
@@ -332,7 +350,9 @@ class TestErrorCategoryMapping:
 
         result = await handler.handle({"note_id": "missing"})
 
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["error"]["category"] == "not_found"
 
     @pytest.mark.asyncio
@@ -345,5 +365,7 @@ class TestErrorCategoryMapping:
 
         result = await handler.handle({"content": "test"})
 
-        response = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response = json.loads(result.content[0].text)
         assert response["error"]["category"] in ["network", "internal"]

--- a/tests/test_tool_handlers.py
+++ b/tests/test_tool_handlers.py
@@ -171,8 +171,9 @@ class TestCreateNoteHandler:
         result = await handler.handle(arguments)
 
         # Should return error response
-        assert isinstance(result, list)
-        response_data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        response_data = json.loads(result.content[0].text)
         assert response_data["success"] is False
 
     @pytest.mark.asyncio
@@ -622,7 +623,9 @@ class TestVaultEncryptionOnCreateAndUpdate:
         result = await handler.handle(
             {"note_id": "note-1", "content": "plaintext replacement"}
         )
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
         assert data["error"]["subcategory"] == "vault_encrypted_note"
@@ -687,7 +690,9 @@ class TestVaultEncryptionOnCreateAndUpdate:
             result = await handler.handle(
                 {"content": "Title\nsensitive", "encrypt": True}
             )
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
         assert data["error"]["subcategory"] == "vault_key_unavailable"
@@ -1034,7 +1039,9 @@ class TestResourceNotFoundErrors:
         """GetNoteHandler error response must include the note_id."""
         handler = GetNoteHandler(mock_client, mock_cache)
         result = await handler.handle({"note_id": "missing-note"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
         # resource_id should appear in error dict
         error = data["error"]
@@ -1047,7 +1054,9 @@ class TestResourceNotFoundErrors:
         """DeleteNoteHandler error response must include the note_id."""
         handler = DeleteNoteHandler(mock_client, mock_cache)
         result = await handler.handle({"note_id": "missing-note"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
         error = data["error"]
         # note_id should appear in context or resource_id
@@ -1201,7 +1210,9 @@ class TestAddTextHandler:
         """update_note returning (None, -1) yields error response."""
         mock_client.update_note.return_value = (None, -1)
         result = await handler.handle({"note_id": "note1", "text": "New text"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
 
@@ -1303,7 +1314,9 @@ class TestListTagsHandler:
         mock_cache.is_initialized = False
         handler = ListTagsHandler(mock_client, mock_cache)
         result = await handler.handle({})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
 
@@ -1519,7 +1532,9 @@ class TestRestoreVersionHandler:
         """If get_note(id, N) fails, return error response."""
         mock_client.get_note.return_value = ({}, -1)
         result = await handler.handle({"note_id": "note1", "version": 99})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
 
@@ -2176,7 +2191,9 @@ class TestReplaceSectionHandler:
                 "new_content": "new content",
             }
         )
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2330,7 +2347,9 @@ class TestFindUntaggedNotesHandler:
         mock_cache.is_initialized = False
         handler = FindUntaggedNotesHandler(mock_client, mock_cache)
         result = await handler.handle({})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
 
@@ -2421,14 +2440,18 @@ class TestBulkTagHandler:
     async def test_missing_note_ids_returns_error(self, handler):
         """Missing note_ids returns an error."""
         result = await handler.handle({"action": "add", "tags": ["x"]})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
     async def test_missing_action_returns_error(self, handler):
         """Missing action returns an error."""
         result = await handler.handle({"note_ids": ["n1"], "tags": ["x"]})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2437,7 +2460,9 @@ class TestBulkTagHandler:
         result = await handler.handle(
             {"note_ids": ["n1"], "action": "explode", "tags": ["x"]}
         )
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2518,7 +2543,9 @@ class TestRestoreNoteHandler:
     async def test_restore_missing_note_id(self, handler):
         """Missing note_id returns error."""
         result = await handler.handle({})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2526,7 +2553,9 @@ class TestRestoreNoteHandler:
         """API failure on get_note returns error."""
         mock_client.get_note.return_value = ({}, -1)
         result = await handler.handle({"note_id": "bad"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
 
@@ -2721,7 +2750,9 @@ class TestPublishNoteHandler:
     async def test_publish_note_missing_note_id(self, handler):
         """publish_note returns error when note_id is missing."""
         result = await handler.handle({})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2733,7 +2764,9 @@ class TestPublishNoteHandler:
         mock_client.get_note.return_value = (None, -1)
         handler = PublishNoteHandler(mock_client, mock_cache)
         result = await handler.handle({"note_id": "bad"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2744,7 +2777,9 @@ class TestPublishNoteHandler:
         mock_client.update_note.return_value = (None, -1)
         handler = PublishNoteHandler(mock_client, mock_cache)
         result = await handler.handle({"note_id": "note123"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2845,7 +2880,9 @@ class TestUnpublishNoteHandler:
     async def test_unpublish_note_missing_note_id(self, handler):
         """unpublish_note returns error when note_id is missing."""
         result = await handler.handle({})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2857,7 +2894,9 @@ class TestUnpublishNoteHandler:
         mock_client.get_note.return_value = (None, -1)
         handler = UnpublishNoteHandler(mock_client, mock_cache)
         result = await handler.handle({"note_id": "bad"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2946,7 +2985,9 @@ class TestEncryptNoteHandler:
     @pytest.mark.asyncio
     async def test_encrypt_note_missing_note_id(self, handler):
         result = await handler.handle({})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -2958,7 +2999,9 @@ class TestEncryptNoteHandler:
         mock_client.token = "fake-token"
         handler = EncryptNoteHandler(mock_client, mock_cache)
         result = await handler.handle({"note_id": "bad"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -3065,7 +3108,9 @@ class TestDecryptNoteHandler:
         handler = DecryptNoteHandler(mock_client, mock_cache)
 
         result = await handler.handle({"note_id": "note123"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
         assert data["error"]["subcategory"] == "decryption_failed"
@@ -3074,7 +3119,9 @@ class TestDecryptNoteHandler:
     @pytest.mark.asyncio
     async def test_decrypt_note_missing_note_id(self, handler):
         result = await handler.handle({})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
         assert data["success"] is False
 
     @pytest.mark.asyncio
@@ -3159,6 +3206,26 @@ class TestVaultStatusHandler:
         registry = ToolHandlerRegistry()
         assert "vault_status" in registry.list_tools()
 
+    @pytest.mark.asyncio
+    async def test_vault_status_reports_corrupted_key_without_crashing(
+        self, handler, tmp_path, monkeypatch
+    ):
+        """A corrupted key file must be reported diagnostically, not raised
+        as an unhandled exception — vault_status is the tool a user would
+        run specifically to diagnose this."""
+        key_file = tmp_path / "vault.key"
+        key_file.write_text("not-valid-base64!!!")
+        monkeypatch.setenv("SIMPLENOTE_VAULT_KEY_FILE", str(key_file))
+
+        result = await handler.handle({})
+
+        assert isinstance(result, list)
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["key_available"] is False
+        assert "key_error" in data
+        assert "vault.key" in data["key_error"]
+
 
 @pytest.mark.unit
 class TestVaultDecryptOnRead:
@@ -3231,6 +3298,28 @@ class TestVaultDecryptOnRead:
         assert "secret" not in json.dumps(data)
         # Title still readable even without the key
         assert data["title"] == "Findable Title"
+
+    @pytest.mark.asyncio
+    async def test_get_note_corrupted_key_surfaces_clear_error_not_silent_null(
+        self, encrypted_note, tmp_path
+    ):
+        """A corrupted key must not look identical to 'no key configured' —
+        that would hide a real, actionable problem from the user."""
+        from simplenote_mcp.server import vault
+
+        vault.reset_for_testing()
+        (tmp_path / "vault.key").write_text("not-valid-base64!!!")
+
+        client, cache = _make_client_and_cache()
+        cache.get_note.return_value = encrypted_note
+        handler = GetNoteHandler(client, cache)
+
+        result = await handler.handle({"note_id": "note1"})
+
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
+        assert data["error"]["subcategory"] == "vault_key_corrupted"
 
     @pytest.mark.asyncio
     async def test_get_note_wrong_key_returns_null_content(self, encrypted_note):
@@ -3332,7 +3421,9 @@ class TestVaultSafetyGuards:
         handler = AddTextHandler(client, cache)
 
         result = await handler.handle({"note_id": "note1", "text": "more stuff"})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
         assert data["error"]["subcategory"] == "vault_encrypted_note"
@@ -3349,7 +3440,9 @@ class TestVaultSafetyGuards:
         result = await handler.handle(
             {"note_id": "note1", "header": "Notes", "new_content": "new stuff"}
         )
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
         assert data["error"]["subcategory"] == "vault_encrypted_note"

--- a/tests/test_tool_handlers_trash.py
+++ b/tests/test_tool_handlers_trash.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock
 
+import mcp.types as types
 import pytest
 
 from simplenote_mcp.server.tool_handlers import (
@@ -106,7 +107,9 @@ class TestPermanentDeleteNoteHandler:
     async def test_missing_note_id_returns_error(self, handler):
         """Missing note_id returns an error response."""
         result = await handler.handle({"confirm": True})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
 
@@ -117,7 +120,9 @@ class TestPermanentDeleteNoteHandler:
         mock_client.get_note.return_value = ({}, -1)
 
         result = await handler.handle({"note_id": "missing", "confirm": True})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
 
@@ -131,7 +136,9 @@ class TestPermanentDeleteNoteHandler:
         mock_client.delete_note.return_value = ("error", -1)
 
         result = await handler.handle({"note_id": "abc", "confirm": True})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
 
@@ -145,7 +152,9 @@ class TestPermanentDeleteNoteHandler:
         mock_client.delete_note.side_effect = RuntimeError("network error")
 
         result = await handler.handle({"note_id": "abc", "confirm": True})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
 
@@ -332,7 +341,9 @@ class TestEmptyTrashHandler:
         mock_client.get_note_list.return_value = ([], -1)
 
         result = await handler.handle({"dry_run": True})
-        data = json.loads(result[0].text)
+        assert isinstance(result, types.CallToolResult)
+        assert result.isError is True
+        data = json.loads(result.content[0].text)
 
         assert data["success"] is False
 

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -218,3 +218,123 @@ class TestKeyProvisioning:
             pytest.raises(vault.VaultKeyUnavailableError),
         ):
             vault.get_or_create_vault_key()
+
+
+@pytest.mark.unit
+class TestKeyFailClosed:
+    """A key file/keychain entry that exists but is corrupt must never be
+    silently regenerated — that would permanently orphan any notes already
+    encrypted with the original key. Missing (never provisioned) must still
+    generate a fresh key as before."""
+
+    def test_missing_key_file_still_generates(self, tmp_path):
+        """Regression guard: only genuinely-absent files are safe to replace."""
+        key_file = tmp_path / "does_not_exist.key"
+        with patch.dict(os.environ, {"SIMPLENOTE_VAULT_KEY_FILE": str(key_file)}):
+            resolved = vault.get_or_create_vault_key()
+        assert len(resolved) == 32
+        assert key_file.exists()
+
+    def test_malformed_base64_key_file_raises_and_is_not_overwritten(self, tmp_path):
+        key_file = tmp_path / "vault.key"
+        key_file.write_text("not-valid-base64!!!")
+        original_content = key_file.read_text()
+
+        with (
+            patch.dict(os.environ, {"SIMPLENOTE_VAULT_KEY_FILE": str(key_file)}),
+            pytest.raises(vault.VaultKeyCorruptedError),
+        ):
+            vault.get_or_create_vault_key()
+
+        assert key_file.read_text() == original_content
+
+    def test_wrong_length_key_file_raises_and_is_not_overwritten(self, tmp_path):
+        key_file = tmp_path / "vault.key"
+        short_key = base64.b64encode(os.urandom(16)).decode("ascii")  # 16, not 32
+        key_file.write_text(short_key)
+
+        with (
+            patch.dict(os.environ, {"SIMPLENOTE_VAULT_KEY_FILE": str(key_file)}),
+            pytest.raises(vault.VaultKeyCorruptedError),
+        ):
+            vault.get_or_create_vault_key()
+
+        assert key_file.read_text() == short_key
+
+    def test_empty_key_file_raises_and_is_not_overwritten(self, tmp_path):
+        key_file = tmp_path / "vault.key"
+        key_file.write_text("")
+
+        with (
+            patch.dict(os.environ, {"SIMPLENOTE_VAULT_KEY_FILE": str(key_file)}),
+            pytest.raises(vault.VaultKeyCorruptedError),
+        ):
+            vault.get_or_create_vault_key()
+
+        assert key_file.read_text() == ""
+
+    def test_unreadable_key_file_raises(self, tmp_path):
+        key_file = tmp_path / "vault.key"
+        key_file.write_text(base64.b64encode(os.urandom(32)).decode("ascii"))
+        key_file.chmod(0o000)
+
+        try:
+            with (
+                patch.dict(os.environ, {"SIMPLENOTE_VAULT_KEY_FILE": str(key_file)}),
+                pytest.raises(vault.VaultKeyCorruptedError),
+            ):
+                vault.get_or_create_vault_key()
+        finally:
+            key_file.chmod(0o600)  # restore so tmp_path cleanup can remove it
+
+    def test_has_vault_key_raises_for_corrupted_file_rather_than_false(self, tmp_path):
+        """A corrupt key must be distinguishable from 'not configured yet' —
+        collapsing both to False would hide a real problem from callers
+        like vault_status."""
+        key_file = tmp_path / "vault.key"
+        key_file.write_text("not-valid-base64!!!")
+
+        with (
+            patch.dict(os.environ, {"SIMPLENOTE_VAULT_KEY_FILE": str(key_file)}),
+            pytest.raises(vault.VaultKeyCorruptedError),
+        ):
+            vault.has_vault_key()
+
+    def test_malformed_base64_in_keyring_raises_and_is_not_overwritten(self):
+        stored = {("simplenote-mcp-vault", "vault-master-key"): "not-valid-base64!!!"}
+
+        def fake_set_password(service, username, password):
+            stored[(service, username)] = password
+
+        def fake_get_password(service, username):
+            return stored.get((service, username))
+
+        with (
+            patch("keyring.get_password", side_effect=fake_get_password),
+            patch("keyring.set_password", side_effect=fake_set_password),
+            pytest.raises(vault.VaultKeyCorruptedError),
+        ):
+            vault.get_or_create_vault_key()
+
+        assert stored[("simplenote-mcp-vault", "vault-master-key")] == (
+            "not-valid-base64!!!"
+        )
+
+    def test_wrong_length_key_in_keyring_raises_and_is_not_overwritten(self):
+        short_key_b64 = base64.b64encode(os.urandom(16)).decode("ascii")
+        stored = {("simplenote-mcp-vault", "vault-master-key"): short_key_b64}
+
+        def fake_set_password(service, username, password):
+            stored[(service, username)] = password
+
+        def fake_get_password(service, username):
+            return stored.get((service, username))
+
+        with (
+            patch("keyring.get_password", side_effect=fake_get_password),
+            patch("keyring.set_password", side_effect=fake_set_password),
+            pytest.raises(vault.VaultKeyCorruptedError),
+        ):
+            vault.get_or_create_vault_key()
+
+        assert stored[("simplenote-mcp-vault", "vault-master-key")] == short_key_b64


### PR DESCRIPTION
## Summary

Resolves 11 of the 12 findings from the security/code-quality audit handoff recorded in CLAUDE.md on 2026-07-13. All findings were re-verified against current code before starting (some same-day commits had landed after the audit was written) — all 11 were confirmed still present.

**P0**
- MCP HTTP transport had no authentication or DNS-rebinding protection — `MCP_TRANSPORT=http` now refuses to start on a non-loopback host without `MCP_HTTP_AUTH_TOKEN`.
- Tool call arguments (note content, search queries) were logged in full at INFO — now only tool name + argument count, sanitized form at DEBUG.

**P1**
- MCP tool errors were indistinguishable from success at the protocol level — now return `CallToolResult(isError=True)`.
- Date-filtered search crashed on every ISO date and rejected every natural-language one.
- A corrupted Vault key could be silently overwritten with a fresh one, orphaning encrypted notes.
- Rate limiting and the write budget were effectively global, not per-client (one decorator was structurally dead code).
- Docker/Helm deployments never actually served anything; health probes only checked that the package imports — fixing that surfaced and fixed a separate bug where `/health` failed on merely "degraded" status.
- The excluded `simplenote_mcp/tests/` suite (112 tests) is restored to CI as an isolated pytest process.

**P2**
- All 25 third-party GitHub Actions pinned to commit SHAs; `secrets: inherit` narrowed to what's actually consumed.
- Production Docker image now installs runtime-only dependencies instead of the full dev/test/security toolchain.
- `Config.validate()` now actually runs at startup.
- `setup.py`'s version/dependency drift fixed and covered by the consistency checker going forward.

**P3** (tool_handlers.py complexity, 111 broad exception handlers) is **intentionally deferred** — the audit itself warned against a broad rewrite. Tracked in ROADMAP.md's new Phase 11.

Full technical detail for each item is in the individual commit messages and CHANGELOG.md's `[Unreleased]` section.

## Notable things found beyond the original 12 findings

- `parse_natural_date` didn't actually handle the underscored date format (`3_days_ago`) the tool schema advertises as an example — only spaced variants worked.
- The monitoring `/health` endpoint returned 503 for merely "degraded" status, not just genuine failures — would have caused Kubernetes liveness restart loops on any lightly-used server once wired to a real probe (this PR does exactly that).
- The offline-mode mock Simplenote client was stateless/contentless, breaking anything that round-tripped a note through create → retrieve/update.

## Test plan

- [x] Full `tests/` suite: 1334 passed, 8 skipped, 79.46% coverage
- [x] `simplenote_mcp/tests/` (separate process): 112 passed, 9 skipped, stable across repeated random-seed runs
- [x] ruff / mypy / bandit clean on every commit
- [x] `check_version_consistency.py`: all 5 sources agree
- [x] Docker image rebuilt and live-tested end-to-end: unauthenticated request → 401, authenticated → 200, health check → healthy
- [x] Helm chart validated with `helm lint` / `helm template`
- [ ] Reviewer: confirm the HTTP auth model choice (bearer-token-gated, private-network use) matches intended deployment — this was flagged as a blocker requiring a decision in the original audit; proceeded with the recommended option, flagging for final sign-off here

🤖 Generated with [Claude Code](https://claude.com/claude-code)