### PR TITLE
fix: correct malformed SHA-pinned action references on main

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.branch-check.outputs.exists == 'true'
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ steps.branch-info.outputs.target_branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set up Python
         if: steps.branch-check.outputs.exists == 'true'
-        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -175,7 +175,7 @@ jobs:
       - name: Find associated PRs
         if: steps.git-check.outputs.changes_made == 'true'
         id: find-pr
-        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const branch = '${{ steps.branch-info.outputs.target_branch }}';
@@ -195,7 +195,7 @@ jobs:
 
       - name: Comment on PR about auto-fixes
         if: steps.git-check.outputs.changes_made == 'true' && steps.find-pr.outputs.result
-        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const prNumber = ${{ steps.find-pr.outputs.result }};

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Check if PR is ready for merge
         id: check
-        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -111,7 +111,7 @@ jobs:
 
       - name: Enable auto-merge
         if: steps.check.outputs.result == 'true'
-        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: 25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,9 +14,9 @@ jobs:
     name: Dependency Review
     steps:
       - name: "📥 Checkout Repository"
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: "🔍 Dependency Review"
-        uses: a1d282b36b6f3519aa1f3fc636f609c47dddb294 # actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           # Fail the workflow if vulnerabilities are found
           fail-on-severity: moderate

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -95,7 +95,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload documentation artifacts
-        uses: fc324d3547104276b827a68afc52ff2a11cc49c9 # actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./site
 
@@ -121,7 +121,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         continue-on-error: true
 
       - name: Handle deployment failure
@@ -145,9 +145,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Download documentation artifacts
-        uses: 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: github-pages
           path: ./site
@@ -158,7 +158,7 @@ jobs:
           tar -xf artifact.tar
 
       - name: Check links
-        uses: e7477775783ea5526144ba13e8db5eec57747ce8 # lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           args: --verbose --no-progress --config .lycheerc.toml './site/**/*.html' --exclude-mail
           fail: false  # Don't fail workflow on link issues, just report them
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload link check report
         if: always()
-        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: link-check-report
           path: lychee-report.md

--- a/.github/workflows/evaluation-quality-gate.yml
+++ b/.github/workflows/evaluation-quality-gate.yml
@@ -52,15 +52,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Python
-        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Set up Node.js
-        uses: 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           # Note: npm cache disabled - package-lock.json may not exist
@@ -283,7 +283,7 @@ jobs:
 
       - name: Upload evaluation artifacts
         if: always()
-        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: evaluation-results-${{ steps.eval-suite.outputs.suite }}
           path: |
@@ -398,7 +398,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.report.outputs.report_created == 'true'
-        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const fs = require('fs');
@@ -443,7 +443,7 @@ jobs:
 
       - name: Create check run
         if: always()
-        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const passRate = '${{ needs.run-evaluations.outputs.pass-rate || '0' }}';
@@ -489,7 +489,7 @@ jobs:
 
       - name: Upload quality gate report
         if: always()
-        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: quality-gate-report
           path: quality-gate-report.md

--- a/.github/workflows/mcp-evaluations.yml
+++ b/.github/workflows/mcp-evaluations.yml
@@ -33,15 +33,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Python
-        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           cache: "pip"
 
       - name: Setup Node.js for mcp-evals
-        uses: 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
           # Note: npm cache disabled - package-lock.json may not exist on scheduled runs
@@ -80,7 +80,7 @@ jobs:
 
       - name: Run smoke tests
         if: steps.check-openai.outputs.has-openai-key == 'true'
-        uses: 614087def55f3b68258580b05f0ae3a7d55207b4 # mclenhard/mcp-evals@v1.0.14
+        uses: mclenhard/mcp-evals@614087def55f3b68258580b05f0ae3a7d55207b4 # v1.0.14
         timeout-minutes: 10
         with:
           evals_path: "evals/smoke-tests.yaml"
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run comprehensive evaluations
         if: (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'comprehensive-eval')) && steps.check-openai.outputs.has-openai-key == 'true'
-        uses: 614087def55f3b68258580b05f0ae3a7d55207b4 # mclenhard/mcp-evals@v1.0.14
+        uses: mclenhard/mcp-evals@614087def55f3b68258580b05f0ae3a7d55207b4 # v1.0.14
         with:
           evals_path: "evals/comprehensive-evals.yaml"
           server_path: "simplenote_mcp_server.py"
@@ -126,7 +126,7 @@ jobs:
 
       - name: Run basic evaluations
         if: github.event_name != 'workflow_dispatch' && steps.check-openai.outputs.has-openai-key == 'true'
-        uses: 614087def55f3b68258580b05f0ae3a7d55207b4 # mclenhard/mcp-evals@v1.0.14
+        uses: mclenhard/mcp-evals@614087def55f3b68258580b05f0ae3a7d55207b4 # v1.0.14
         with:
           evals_path: "evals/simplenote-evals.yaml"
           server_path: "simplenote_mcp_server.py"
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload evaluation summary
         if: always()
-        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: evaluation-summary
           path: evaluation-summary.md
@@ -174,12 +174,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0 # Need full history for diff
 
       - name: Setup Node.js for mcp-evals
-        uses: 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
           # Note: npm cache disabled - package-lock.json may not exist
@@ -252,7 +252,7 @@ jobs:
 
       - name: Comment on PR with evaluation info
         if: steps.eval-changes.outputs.eval_files_changed == 'true' && github.event_name == 'pull_request'
-        uses: 373c709c69115d41ff229c7e5df9f8788daa9553 # actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         continue-on-error: true
         with:
           script: |

--- a/.github/workflows/monitoring-consolidated.yml
+++ b/.github/workflows/monitoring-consolidated.yml
@@ -56,9 +56,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Python
-        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload security reports
         if: always()
-        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: security-reports-${{ github.run_id }}
           path: |
@@ -113,9 +113,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Python
-        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -164,7 +164,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Validate README badges
         run: |
           echo "Validating badges in README.md..."

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,11 +15,11 @@ jobs:
     permissions:
       id-token: write  # required for OIDC Trusted Publishing
     steps:
-      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.inputs.tag }}
 
-      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.13"
 
@@ -29,6 +29,6 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: cef221092ed1bacb1cc03d23a2d87d1d172e277b # pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           skip-existing: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -155,7 +155,7 @@ jobs:
       - name: Create GitHub Release
         id: create_release
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: c12583777ecdfd3be55c69cf75464299dc01057e # softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@c12583777ecdfd3be55c69cf75464299dc01057e # v3
         with:
           name: "v${{ steps.bump_version.outputs.new_version }}"
           tag_name: "v${{ steps.bump_version.outputs.new_version }}"
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload changelog artifact
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: changelog-${{ steps.bump_version.outputs.new_version }}
           path: changelog.md
@@ -187,12 +187,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: v${{ needs.prepare-release.outputs.new_version }}
 
       - name: Set up Python
-        uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -375,7 +375,7 @@ jobs:
           echo "✅ SBOM and vulnerability report generation completed"
 
       - name: Upload SBOM and vulnerability artifacts
-        uses: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: security-reports-${{ needs.prepare-release.outputs.new_version }}
           path: |
@@ -387,7 +387,7 @@ jobs:
 
       - name: Publish to PyPI
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: cef221092ed1bacb1cc03d23a2d87d1d172e277b # pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           skip-existing: false
 
@@ -405,7 +405,7 @@ jobs:
 
     steps:
       - name: Download security artifacts
-        uses: 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: security-reports-${{ needs.prepare-release.outputs.new_version }}
           path: security-reports/
@@ -416,7 +416,7 @@ jobs:
           ls -la security-reports/
           
       - name: Attach SBOM and vulnerability reports to release
-        uses: c12583777ecdfd3be55c69cf75464299dc01057e # softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@c12583777ecdfd3be55c69cf75464299dc01057e # v3
         with:
           tag_name: "v${{ needs.prepare-release.outputs.new_version }}"
           files: |

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
@@ -40,13 +40,13 @@ jobs:
             echo "Warning: Large file detected: $file ($(du -h "$file" | cut -f1))"
           done
 
-      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
 
       - name: Cache dependencies
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         id: cache
         with:
           path: |
@@ -78,14 +78,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
-      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
 
       - name: Restore dependencies
-        uses: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cache/pip
@@ -125,7 +125,7 @@ jobs:
           pytest simplenote_mcp/tests/ --randomly-seed=${{ github.run_id }} --no-cov
 
       - name: Upload coverage
-        uses: a99c28d3f0da835de33ff2feb2e15691c7b9641f # codecov/codecov-action@v7
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
         with:
           file: ./coverage.xml
           fail_ci_if_error: true
@@ -136,8 +136,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
-      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -168,21 +168,21 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up QEMU
-        uses: 96fe6ef7f33517b61c61be40b68a1882f3264fb8 # docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
-        uses: bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         with:
           version: latest
           platforms: linux/amd64,linux/arm64
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: af1e73f918a031802d376d3c8bbc3fe56130a9b0 # docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -190,7 +190,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: af1e73f918a031802d376d3c8bbc3fe56130a9b0 # docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -198,7 +198,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: dc802804100637a589fabce1cb79ff13a1411302 # docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: 53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile
@@ -228,7 +228,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: github.event_name != 'pull_request'
-        uses: a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           format: "sarif"
@@ -239,14 +239,14 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: github.event_name != 'pull_request'
-        uses: 1ad29ea4a422cce9a242a9fae469541dcd08addc # github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
         with:
           sarif_file: "trivy-results.sarif"
           category: "trivy-container-scan"
 
       - name: Update Docker Hub repository description
         if: github.event_name != 'pull_request'
-        uses: 1b9a80c056b620d92cedb9d9b5a223409c68ddfa # peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -259,8 +259,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
-      - uses: ece7cb06caefa5fff74198d8649806c4678c61a1 # actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -80,7 +80,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: 5f6978faf089d4d20b00c7766989d076bb2fc7f1 # peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |


### PR DESCRIPTION
## Summary

PR #699 (the 2026-07-13 security & code quality audit remediation) was merged directly via GitHub before a critical follow-up fix was pushed to the branch. As a result, `main` currently has invalid `uses:` values in 11 workflow files under `.github/workflows/`, and **every workflow that includes an affected file will create zero jobs** (GitHub's schema validator rejects the malformed `uses:` lines outright — confirmed via `gh api .../actions/runs/<id>/jobs` returning `{"total_count":0,"jobs":[]}` on the pre-fix branch).

### Root cause

Phase E1 of the audit remediation pinned third-party Action references to commit SHAs. The regex used to do this had a bug: it replaced the entire `owner/repo@tag` match with a bare SHA plus a trailing comment, instead of substituting just the `@tag` portion. That produced invalid forms like:

```yaml
uses: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
```

instead of the valid:

```yaml
uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
```

This is syntactically valid YAML (so a plain `yaml.safe_load()` check passed at the time) but semantically invalid per GitHub's Actions workflow schema, which requires `uses:` to be `owner/repo@ref`.

### Fix

Re-derives the correct `owner/repo@sha # tag` form from each broken line's own preserved comment across all 11 affected files. No behavioral change beyond restoring valid pinning — same SHAs, same tags, just correctly positioned.

### Verification

- `actionlint .github/workflows/*.yml` — zero `uses:`-related findings (only pre-existing, unrelated shellcheck/style warnings that predate this branch).
- Manually grepped for the broken pattern (`uses: [a-f0-9]{40} #`) across `.github/workflows/` — zero matches after the fix.
- This is the same fix that was tested and verified before PR #699 merged; it just didn't land in time.

## Test plan

- [x] `actionlint` clean on all workflow files
- [x] No bare-SHA `uses:` lines remain
- [ ] Confirm this PR's own CI actually runs jobs (proves the fix works, since the broken version would show 0 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct malformed SHA-only GitHub Actions references throughout the workflows by restoring the proper owner/repo@sha format, ensuring all CI and automation workflows on main can run jobs again while retaining the existing pins.

Bug Fixes:
- Restore valid SHA-pinned action references in all affected GitHub workflow files so jobs run correctly again.

Enhancements:
- Standardize GitHub Actions pinning format to explicit owner/repo@sha with trailing tag comments across CI, release, docs, monitoring, and automation workflows.

Build:
- Update multiple workflow definitions under .github/workflows to use correctly formatted GitHub Actions references without changing pinned SHAs or behavior.

CI:
- Fix malformed action references in core CI, release, documentation, monitoring, auto-fix, auto-merge, dependency review, and PyPI publish workflows to ensure they execute as expected.