### PR TITLE
fix: close script-injection + npm supply-chain follow-ups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,29 @@ updates:
       - "dependencies"
       - "github-actions"
 
+  # npm (MCP evaluation tooling — devDependencies only, not shipped)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    assignees:
+      - "docdyhr"
+
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
   # Docker
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -176,9 +176,11 @@ jobs:
         if: steps.git-check.outputs.changes_made == 'true'
         id: find-pr
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          TARGET_BRANCH: ${{ steps.branch-info.outputs.target_branch }}
         with:
           script: |
-            const branch = '${{ steps.branch-info.outputs.target_branch }}';
+            const branch = process.env.TARGET_BRANCH;
 
             if (branch === 'main') {
               return null;
@@ -196,18 +198,23 @@ jobs:
       - name: Comment on PR about auto-fixes
         if: steps.git-check.outputs.changes_made == 'true' && steps.find-pr.outputs.result
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          PR_NUMBER: ${{ steps.find-pr.outputs.result }}
+          FORMAT_FIXES_NEEDED: ${{ steps.check-issues.outputs.format_fixes_needed }}
+          IMPORT_FIXES: ${{ steps.check-issues.outputs.import_fixes }}
+          WHITESPACE_FIXES: ${{ steps.check-issues.outputs.whitespace_fixes }}
         with:
           script: |
-            const prNumber = ${{ steps.find-pr.outputs.result }};
+            const prNumber = Number(process.env.PR_NUMBER);
             const fixes = [];
 
-            if ('${{ steps.check-issues.outputs.format_fixes_needed }}' === 'true') {
+            if (process.env.FORMAT_FIXES_NEEDED === 'true') {
               fixes.push('Code formatting');
             }
-            if ('${{ steps.check-issues.outputs.import_fixes }}' === 'true') {
+            if (process.env.IMPORT_FIXES === 'true') {
               fixes.push('Import sorting');
             }
-            if ('${{ steps.check-issues.outputs.whitespace_fixes }}' === 'true') {
+            if (process.env.WHITESPACE_FIXES === 'true') {
               fixes.push('Whitespace cleanup');
             }
 

--- a/.github/workflows/evaluation-quality-gate.yml
+++ b/.github/workflows/evaluation-quality-gate.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
     paths:
       - "simplenote_mcp/**"
-      - "tests/**" 
+      - "tests/**"
       - "evals/**"
       - "pyproject.toml"
       - "package.json"
@@ -32,8 +32,8 @@ on:
         type: number
 
 env:
-  NODE_VERSION: '18'
-  PYTHON_VERSION: '3.12'
+  NODE_VERSION: "18"
+  PYTHON_VERSION: "3.12"
 
 permissions:
   contents: read
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
+          cache: "pip"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -80,7 +80,7 @@ jobs:
         run: |
           SUITE="${{ github.event.inputs.evaluation_suite || 'basic' }}"
           echo "suite=${SUITE}" >> $GITHUB_OUTPUT
-          
+
           case "${SUITE}" in
             smoke)
               echo "timeout=5" >> $GITHUB_OUTPUT
@@ -126,7 +126,7 @@ jobs:
         timeout-minutes: ${{ fromJSON(steps.eval-suite.outputs.timeout) }}
         run: |
           echo "Running ${{ steps.eval-suite.outputs.description }}..."
-          
+
           # Run evaluations and capture results
           case "${{ steps.eval-suite.outputs.suite }}" in
             smoke)
@@ -139,15 +139,15 @@ jobs:
               timeout 1200s npm run eval:comprehensive > evaluation-output.txt 2>&1
               ;;
           esac
-          
+
           EVAL_EXIT_CODE=$?
           echo "exit_code=${EVAL_EXIT_CODE}" >> $GITHUB_OUTPUT
-          
+
           # Display results
           echo "=== Evaluation Output ==="
           cat evaluation-output.txt
           echo "========================="
-          
+
           # Save output for later steps
           cp evaluation-output.txt eval-results.txt
 
@@ -160,7 +160,7 @@ jobs:
           import sys
           import os
           from pathlib import Path
-          
+
           def parse_evaluation_results(output_file):
               """Parse MCP evaluation results from output."""
               try:
@@ -228,10 +228,10 @@ jobs:
                   results["status"] = "poor"
               
               return results
-          
+
           # Parse results
           results = parse_evaluation_results('eval-results.txt')
-          
+
           if results:
               # Set outputs
               pass_rate = results["pass_rate"]
@@ -266,7 +266,7 @@ jobs:
                       "threshold": fail_threshold,
                       "quality_gate_passed": quality_gate_passed
                   }, f, indent=2)
-          
+
           else:
               print("Failed to parse evaluation results")
               # Set default outputs
@@ -300,7 +300,7 @@ jobs:
     permissions:
       pull-requests: write
       checks: write
-    
+
     steps:
       - name: Create quality gate report
         id: report
@@ -308,9 +308,9 @@ jobs:
           PASS_RATE="${{ needs.run-evaluations.outputs.pass-rate || '0' }}"
           QUALITY_GATE_PASSED="${{ needs.run-evaluations.outputs.quality-gate-passed || 'false' }}"
           STATUS="${{ needs.run-evaluations.outputs.status || 'unknown' }}"
-          
+
           echo "Creating quality gate report..."
-          
+
           # Determine overall result
           if [ "${{ needs.run-evaluations.result }}" = "success" ] && [ "${QUALITY_GATE_PASSED}" = "true" ]; then
             OVERALL_STATUS="✅ PASSED"
@@ -322,22 +322,22 @@ jobs:
             OVERALL_STATUS="❌ FAILED"
             GATE_EMOJI="🔴"
           fi
-          
+
           # Create report
           cat > quality-gate-report.md << EOF
           # ${GATE_EMOJI} Evaluation Quality Gate Report
-          
+
           ## Overall Result: ${OVERALL_STATUS}
-          
+
           **Pass Rate**: ${PASS_RATE}%  
           **Threshold**: ${{ github.event.inputs.fail_threshold || '70' }}%  
           **Evaluation Suite**: ${{ github.event.inputs.evaluation_suite || 'basic' }}  
           **Quality Gate**: ${QUALITY_GATE_PASSED}
-          
+
           ## Assessment
-          
+
           EOF
-          
+
           # Add assessment based on status
           case "${STATUS}" in
             success)
@@ -368,11 +368,11 @@ jobs:
               echo "Please review the evaluation logs for more information." >> quality-gate-report.md
               ;;
           esac
-          
+
           echo "" >> quality-gate-report.md
           echo "## Recommendations" >> quality-gate-report.md
           echo "" >> quality-gate-report.md
-          
+
           if [ "${QUALITY_GATE_PASSED}" = "false" ]; then
             echo "- 🔍 **Review failed evaluations** in the uploaded artifacts" >> quality-gate-report.md
             echo "- 🛠️ **Fix failing test scenarios** to improve pass rate" >> quality-gate-report.md
@@ -383,17 +383,17 @@ jobs:
             echo "- 📊 **Monitor evaluation trends** over time" >> quality-gate-report.md
             echo "- 🎯 **Consider running comprehensive evaluations** for important changes" >> quality-gate-report.md
           fi
-          
+
           echo "" >> quality-gate-report.md
           echo "---" >> quality-gate-report.md
           echo "*Quality gate is currently non-blocking. This assessment is for informational purposes.*" >> quality-gate-report.md
           echo "" >> quality-gate-report.md
           echo "📁 **Evaluation artifacts**: Check the Actions tab for detailed results" >> quality-gate-report.md
-          
+
           # Output for next steps
           echo "overall_status=${OVERALL_STATUS}" >> $GITHUB_OUTPUT
           echo "report_created=true" >> $GITHUB_OUTPUT
-          
+
           cat quality-gate-report.md
 
       - name: Comment on PR
@@ -402,7 +402,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            
+
             try {
               const report = fs.readFileSync('quality-gate-report.md', 'utf8');
               
@@ -444,14 +444,20 @@ jobs:
       - name: Create check run
         if: always()
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          PASS_RATE: ${{ needs.run-evaluations.outputs.pass-rate || '0' }}
+          QUALITY_GATE_PASSED: ${{ needs.run-evaluations.outputs.quality-gate-passed }}
+          EVAL_RESULT: ${{ needs.run-evaluations.result }}
+          FAIL_THRESHOLD: ${{ github.event.inputs.fail_threshold || '70' }}
+          EVALUATION_SUITE: ${{ github.event.inputs.evaluation_suite || 'basic' }}
         with:
           script: |
-            const passRate = '${{ needs.run-evaluations.outputs.pass-rate || '0' }}';
-            const qualityGatePassed = '${{ needs.run-evaluations.outputs.quality-gate-passed }}' === 'true';
-            const evalResult = '${{ needs.run-evaluations.result }}';
-            
+            const passRate = process.env.PASS_RATE;
+            const qualityGatePassed = process.env.QUALITY_GATE_PASSED === 'true';
+            const evalResult = process.env.EVAL_RESULT;
+
             let conclusion, title, summary;
-            
+
             if (evalResult === 'success' && qualityGatePassed) {
               conclusion = 'success';
               title = '✅ Quality Gate Passed';
@@ -465,7 +471,7 @@ jobs:
               title = '❌ Evaluation Failed';
               summary = `Evaluations failed to complete successfully (non-blocking)`;
             }
-            
+
             await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -477,11 +483,11 @@ jobs:
                 summary: summary,
                 text: `
             This is a non-blocking quality gate based on MCP evaluation results.
-            
+
             **Pass Rate**: ${passRate}%
-            **Threshold**: ${{ github.event.inputs.fail_threshold || '70' }}%
-            **Suite**: ${{ github.event.inputs.evaluation_suite || 'basic' }}
-            
+            **Threshold**: ${process.env.FAIL_THRESHOLD}%
+            **Suite**: ${process.env.EVALUATION_SUITE}
+
             Check the evaluation artifacts for detailed results.
                 `
               }

--- a/.github/workflows/mcp-evaluations.yml
+++ b/.github/workflows/mcp-evaluations.yml
@@ -254,10 +254,12 @@ jobs:
         if: steps.eval-changes.outputs.eval_files_changed == 'true' && github.event_name == 'pull_request'
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         continue-on-error: true
+        env:
+          HAS_OPENAI_KEY: ${{ needs.evaluate-mcp-server.outputs.has-openai-key || 'false' }}
         with:
           script: |
             const changedFiles = process.env.CHANGED_FILES || 'See file diff above';
-            const hasOpenAI = '${{ needs.evaluate-mcp-server.outputs.has-openai-key || 'false' }}' === 'true';
+            const hasOpenAI = process.env.HAS_OPENAI_KEY === 'true';
 
             const body = `## 🧪 Evaluation Files Updated
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.23.tgz",
-      "integrity": "sha512-86U7rFp8yacUAOE/Jz8WbGcwMCqWvjK33wk5DXkfnAOEn3mx2r7tNSJdjukQFZbAK97VMXGPPHxF+aEARDXRXQ==",
+      "version": "1.3.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
+      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -620,24 +620,14 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
-      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
@@ -645,15 +635,15 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
+        "protobufjs": "^7.5.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -664,9 +654,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1395,13 +1385,13 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
-      "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/core": "2.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1412,9 +1402,9 @@
       }
     },
     "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1568,15 +1558,34 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1587,9 +1596,9 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1655,6 +1664,22 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.36.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
@@ -1680,41 +1705,33 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1733,9 +1750,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2502,13 +2519,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2528,9 +2545,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -2563,17 +2580,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2791,9 +2808,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2804,9 +2821,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2882,9 +2899,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2959,10 +2976,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3382,25 +3409,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3421,13 +3447,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3667,15 +3694,15 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3687,14 +3714,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3919,16 +3946,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -4064,9 +4088,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "license": "MIT",
   "dependencies": {
     "tsx": "^4.20.3"
+  },
+  "overrides": {
+    "undici": "^6.27.0"
   }
 }


### PR DESCRIPTION
## Summary

Two follow-up items from the 2026-07-13 audit remediation (#699/#702), both flagged during final review rather than being new findings from scratch:

### 1. GitHub Actions script-injection hardening

Sourcery/opengrep flagged raw `${{ }}` interpolation of `github.event.inputs.*` and `needs.*.outputs.*` directly inside `actions/github-script` `script:` bodies in `evaluation-quality-gate.yml`. That pattern lets a value containing a quote character break out of the JS string literal before the script is parsed. Applied the standard `env:` + `process.env.*` fix — found and fixed the same pattern in two other workflows (`auto-fix.yml`, `mcp-evaluations.yml`) via a repo-wide scan, not just the two lines originally flagged.

All affected values were already low-risk (`workflow_dispatch` inputs or same-repo job outputs, not fork-controlled), but closing the pattern removes the class of bug entirely rather than leaving structurally identical instances unpatched.

### 2. npm supply-chain vulnerabilities (41 open Dependabot alerts)

Newly visible after `package-lock.json` was un-gitignored and committed in #699. All are transitive dependencies of `mcp-evals`, a `devDependency` in a `"private": true` npm package used only for local/CI `npm run eval:*` tooling — **never shipped** in the Docker image or PyPI package (confirmed no `node_modules`/`package.json` references anywhere in `Dockerfile`, `MANIFEST.in`, or `pyproject.toml`).

- `npm audit fix` (non-forcing — only resolves within already-allowed semver ranges): fixed **protobufjs (CRITICAL — arbitrary code execution)**, hono, form-data, fast-uri, js-yaml, qs, ip-address, `@hono/node-server`, `@protobufjs/utf8`, express-rate-limit, `@grpc/grpc-js`.
- Added a `package.json` `overrides` entry pinning `undici` to `^6.27.0`. It's nested under `@actions/http-client@2.2.3` (itself pulled in by `@actions/core`, a transitive dep of `mcp-evals`), which declares `undici ^5.25.4` — too old for 9 open advisories (HTTP request/response smuggling, decompression-bomb DoS, WebSocket issues). `@actions/http-client`'s own latest release (4.0.1) already depends on `undici ^6.23.0`, so this override just pulls forward what upstream already moved to.
- **Deliberately not fixed**: ~28 remaining alerts (`@opentelemetry/*`, `@ai-sdk/*`, `ai`, `jsondiffpatch`) all require `npm audit fix --force`, which downgrades `mcp-evals` 2.0.1 → 1.0.18 (the last pre-2.0 release, before these deps existed in the tree) — there's no newer 2.x release upstream yet that fixes them. That's a functional-regression judgment call on core eval tooling, not a mechanical fix, so it's left open rather than forced through silently. Real-world exposure is low (dev-only tooling, not internet-facing, talks only to trusted GitHub/Anthropic/OpenAI endpoints).
- Added an `npm` ecosystem block to `dependabot.yml` (mirroring the existing `pip` block's structure) — it was previously **entirely absent**, which is the root cause these accumulated silently; only GitHub's separate, unscheduled "security updates" automation caught a subset (PR #701, 7 of the 41 alerts, still open — recommend merging that too).

## Verification

- `actionlint` clean on all 3 touched workflow files (only pre-existing, unrelated shellcheck/style warnings)
- No `${{ }}` interpolation remains inside any `github-script` `script:` body (repo-wide scan)
- `npm ls` shows a clean, non-broken dependency tree
- `package-lock.json` is valid JSON
- `npm run validate:evals` passes
- `python3 -c "import yaml; yaml.safe_load(...)"` clean on updated `dependabot.yml`

## Test plan

- [x] actionlint clean
- [x] npm dependency tree resolves cleanly
- [x] eval YAML files still validate
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden GitHub Actions workflows against script-injection issues and address npm supply-chain vulnerabilities in dev-only tooling.

Bug Fixes:
- Prevent potential script-injection in github-script steps by routing workflow inputs and job outputs through environment variables instead of direct string interpolation.
- Mitigate known vulnerabilities in the undici HTTP client dependency used via dev tooling by pinning it to a secure version.

Enhancements:
- Improve evaluation-quality-gate workflow robustness and consistency through minor formatting and quoting cleanups.
- Clarify handling of MCP evaluation status reporting in workflows by standardizing environment-based configuration for GitHub Script steps.

Build:
- Add an npm dependency override in package.json to ensure undici resolves to a more secure release in the dev dependency tree.

CI:
- Configure Dependabot to monitor npm dependencies for the project’s MCP evaluation tooling, with grouped dependency update PRs.