### PR TITLE
docs: address Sourcery follow-ups from PR #703

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -176,6 +176,10 @@ jobs:
         if: steps.git-check.outputs.changes_made == 'true'
         id: find-pr
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        # Convention: pass workflow/job values in via env: and read them from process.env
+        # in the script below. Do NOT interpolate ${{ }} directly into the script: body —
+        # an untrusted value containing a quote can break out of the JS string literal
+        # (script injection). See https://github.com/docdyhr/simplenote-mcp-server/pull/703
         env:
           TARGET_BRANCH: ${{ steps.branch-info.outputs.target_branch }}
         with:

--- a/.github/workflows/evaluation-quality-gate.yml
+++ b/.github/workflows/evaluation-quality-gate.yml
@@ -444,6 +444,10 @@ jobs:
       - name: Create check run
         if: always()
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        # Convention: pass workflow/job values in via env: and read them from process.env
+        # in the script below. Do NOT interpolate ${{ }} directly into the script: body —
+        # an untrusted value containing a quote can break out of the JS string literal
+        # (script injection). See https://github.com/docdyhr/simplenote-mcp-server/pull/703
         env:
           PASS_RATE: ${{ needs.run-evaluations.outputs.pass-rate || '0' }}
           QUALITY_GATE_PASSED: ${{ needs.run-evaluations.outputs.quality-gate-passed }}

--- a/.github/workflows/mcp-evaluations.yml
+++ b/.github/workflows/mcp-evaluations.yml
@@ -254,6 +254,10 @@ jobs:
         if: steps.eval-changes.outputs.eval_files_changed == 'true' && github.event_name == 'pull_request'
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         continue-on-error: true
+        # Convention: pass workflow/job values in via env: and read them from process.env
+        # in the script below. Do NOT interpolate ${{ }} directly into the script: body —
+        # an untrusted value containing a quote can break out of the JS string literal
+        # (script injection). See https://github.com/docdyhr/simplenote-mcp-server/pull/703
         env:
           HAS_OPENAI_KEY: ${{ needs.evaluate-mcp-server.outputs.has-openai-key || 'false' }}
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,21 @@ For test coverage:
 pytest --cov=simplenote_mcp tests/
 ```
 
+### GitHub Actions Workflows
+
+When adding or editing an `actions/github-script` step in `.github/workflows/`, never interpolate `${{ }}` directly into the `script:` body. A value containing a quote character can break out of the JS string literal before the script is even parsed — a script-injection vector (see [PR #703](https://github.com/docdyhr/simplenote-mcp-server/pull/703)). Instead, pass values through `env:` and read them via `process.env` in the script:
+
+```yaml
+- uses: actions/github-script@<sha> # vX
+  env:
+    SOME_VALUE: ${{ steps.previous.outputs.some_value }}
+  with:
+    script: |
+      const someValue = process.env.SOME_VALUE;
+```
+
+Validate workflow edits with `actionlint` (schema-aware), not just a YAML syntax checker — a malformed `uses:` value can be valid YAML while still being rejected by GitHub's Actions schema.
+
 ## Pull Request Process
 
 1. Create a new branch for your feature or bugfix

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,6 +87,8 @@ For detailed information about our automated security monitoring and maintenance
 - **Vulnerability Scanning**: Automated scanning using OSV and Safety databases
 - **SBOM Generation**: Software Bill of Materials for transparency
 - **License Compliance**: Automated license compliance checking
+- **GitHub Actions**: third-party actions pinned to commit SHAs (not mutable tags), validated with `actionlint`
+- **npm `overrides` in `package.json`**: `undici` is pinned to `^6.27.0` via `overrides`, forcing a version newer than the `^5.25.4` declared by `@actions/http-client@2.2.3` (nested under `@actions/core` → `mcp-evals`, a devDependency used only for local/CI evaluation tooling — never shipped in the Docker image or PyPI package). The override closes 9 undici advisories (HTTP request/response smuggling, decompression-bomb DoS, WebSocket issues) that the pinned `@actions/http-client` version predates; `@actions/http-client`'s own latest release (4.0.1) already depends on `undici ^6.23.0`, so this pulls forward what upstream already moved to. Before removing this override, confirm a newer `@actions/http-client`/`@actions/core`/`mcp-evals` release has picked up a safe `undici` version on its own (`npm ls undici`).
 
 ## 📋 Security Architecture
 


### PR DESCRIPTION
## Summary

Two suggestions from Sourcery's review on #703 (both non-blocking, but worth closing out):

1. **Standardize the `env:`/`process.env` script-injection-safe pattern.** Added an inline comment at each `github-script` step that uses it (`evaluation-quality-gate.yml`, `auto-fix.yml`, `mcp-evaluations.yml`) — right where a future contributor would be tempted to add a new `${{ }}` interpolation — plus a new "GitHub Actions Workflows" section in `CONTRIBUTING.md` with a copy-pasteable example, for anyone writing a new workflow from scratch.

2. **Document the `undici` override's rationale somewhere discoverable.** `package.json` is pure JSON and can't hold a comment, so added it to `SECURITY.md`'s existing "Supply Chain Security" section instead, alongside the SHA-pinning note — the natural place a future maintainer would look before removing an override they don't understand.

Sourcery's review also independently classified the bug fixed in #703 as "Remote code execution (RCE) via untrusted code execution in CI workflows," which is a useful confirmation the original fix was worth doing.

## Verification

- `actionlint` on all 3 touched workflow files: identical finding count to before (43, all pre-existing shellcheck style notes + 1 pre-existing `[expression]` finding) — the added comments introduce nothing new
- YAML syntax valid on all 3 files
- Doc changes are prose-only, no code paths affected

## Test plan

- [x] actionlint clean (no new findings)
- [x] YAML valid
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document CI script-injection safeguards and supply chain overrides across workflows and security docs.

CI:
- Annotate github-script steps in auto-fix, evaluation-quality-gate, and mcp-evaluations workflows with inline comments standardizing the env/process.env convention to avoid script injection.

Documentation:
- Add CONTRIBUTING guidance for safely passing values into actions/github-script via env/process.env and validating workflows with actionlint.
- Expand SECURITY.md to document GitHub Actions SHA pinning and the undici npm override rationale and usage context.