### PR TITLE
fix: use project .venv consistently across eval tooling and dev scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immediately with `ModuleNotFoundError: No module named 'mcp'` and the MCP client saw a bare
   "Connection closed". Now prefers `.venv/bin/python3` when present, falling back to `python3`
   for environments without a local venv (CI/Docker). The same class of bug existed in
-  `setup-dev-env-with-evals.sh` (installed deps via bare `pip` with no venv created/activated),
-  `test-ci-locally.sh`, and `test-mcp-evals.sh` (both ran bare `python3`/`pip`/`ruff`/`mypy`) — all
-  three now create/activate `.venv` before running anything. `docker-entrypoint.sh` was left as-is:
-  the Docker image installs dependencies straight into its own system Python with no venv, so bare
-  `python` there is already correct.
+  `setup-dev-env-with-evals.sh` (installed deps via bare `pip` with no venv created/activated) and
+  `test-mcp-evals.sh` (ran bare `python3`) — both now create/activate `.venv` when present.
+  `test-ci-locally.sh` now activates `.venv` too, but only when it exists: CI's own `local-test`
+  job runs this exact script with no `.venv` (deps installed straight into the runner's Python,
+  same as Docker), so an unconditional activation requirement broke that job — this is a no-op
+  there, matching `test-mcp-evals.sh`'s pattern. `docker-entrypoint.sh` was left as-is: the Docker
+  image installs dependencies straight into its own system Python with no venv, so bare `python`
+  there is already correct.
 - **Shutdown could log a spurious `asyncio.exceptions.InvalidStateError`**: `monitor_shutdown()`
   called `shutdown_future.set_result(None)` unconditionally once `shutdown_requested` flipped true.
   If the future had already been resolved or cancelled by the time the poll loop noticed (observed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 27 registered tools → 30 (9 read + 21 write).
 
 ### Fixed
+- **Every `npm run eval:*` suite was broken by a wrong Python interpreter**: `mcp-server-wrapper.ts`
+  spawned the MCP server via bare `spawn("python3", ...)`, which resolves to whatever's first on
+  PATH — Homebrew's or pyenv's global Python — not this project's `.venv`. Since the `mcp` package
+  (and everything else the server imports) is only installed in `.venv`, every eval run crashed
+  immediately with `ModuleNotFoundError: No module named 'mcp'` and the MCP client saw a bare
+  "Connection closed". Now prefers `.venv/bin/python3` when present, falling back to `python3`
+  for environments without a local venv (CI/Docker). The same class of bug existed in
+  `setup-dev-env-with-evals.sh` (installed deps via bare `pip` with no venv created/activated),
+  `test-ci-locally.sh`, and `test-mcp-evals.sh` (both ran bare `python3`/`pip`/`ruff`/`mypy`) — all
+  three now create/activate `.venv` before running anything. `docker-entrypoint.sh` was left as-is:
+  the Docker image installs dependencies straight into its own system Python with no venv, so bare
+  `python` there is already correct.
+- **Shutdown could log a spurious `asyncio.exceptions.InvalidStateError`**: `monitor_shutdown()`
+  called `shutdown_future.set_result(None)` unconditionally once `shutdown_requested` flipped true.
+  If the future had already been resolved or cancelled by the time the poll loop noticed (observed
+  during SIGTERM teardown races), `set_result` raised `InvalidStateError('invalid state')` as an
+  unretrieved task exception. Cosmetic only — the server still exited 0 — but now guarded with a
+  `.done()` check before calling `set_result`.
 - **`read_resource` crashed over the real MCP wire protocol**: `handle_read_resource` returned a
   pre-built `types.ReadResourceResult`, but the SDK's `@server.read_resource()` decorator expects
   the handler to return `str | bytes | Iterable[ReadResourceContents]` and wraps that into a

--- a/mcp-server-wrapper.ts
+++ b/mcp-server-wrapper.ts
@@ -5,43 +5,51 @@
  * This allows mcp-evals to work with the Python server by providing a TypeScript entry point
  */
 
-import { spawn } from 'child_process';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { spawn } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
 
 // Get current directory
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Path to the Python server
-const PYTHON_SERVER_PATH = path.join(__dirname, 'simplenote_mcp_server.py');
+const PYTHON_SERVER_PATH = path.join(__dirname, "simplenote_mcp_server.py");
+// Prefer the project virtualenv's interpreter so the server sees its installed
+// dependencies (e.g. the `mcp` package) instead of whatever `python3` resolves
+// to on PATH.
+const VENV_PYTHON_PATH = path.join(__dirname, ".venv", "bin", "python3");
 
 async function main() {
   try {
     // Check if Python server exists
-    const fs = await import('fs');
+    const fs = await import("fs");
     if (!fs.existsSync(PYTHON_SERVER_PATH)) {
       console.error(`Python server not found at: ${PYTHON_SERVER_PATH}`);
       process.exit(1);
     }
 
+    const pythonExecutable = fs.existsSync(VENV_PYTHON_PATH)
+      ? VENV_PYTHON_PATH
+      : "python3";
+
     // Start the Python MCP server as a child process
-    const pythonProcess = spawn('python3', [PYTHON_SERVER_PATH], {
-      stdio: ['pipe', 'pipe', 'inherit'], // stdin, stdout, stderr
+    const pythonProcess = spawn(pythonExecutable, [PYTHON_SERVER_PATH], {
+      stdio: ["pipe", "pipe", "inherit"], // stdin, stdout, stderr
       env: {
         ...process.env,
         // Ensure MCP server runs in the right mode
-        LOG_LEVEL: 'INFO'
-      }
+        LOG_LEVEL: "INFO",
+      },
     });
 
     // Handle Python process errors
-    pythonProcess.on('error', (error) => {
-      console.error('Failed to start Python server:', error);
+    pythonProcess.on("error", (error) => {
+      console.error("Failed to start Python server:", error);
       process.exit(1);
     });
 
-    pythonProcess.on('exit', (code, signal) => {
+    pythonProcess.on("exit", (code, signal) => {
       console.error(`Python server exited with code ${code}, signal ${signal}`);
       process.exit(code || 1);
     });
@@ -55,33 +63,32 @@ async function main() {
     // Handle process termination
     const cleanup = () => {
       if (!pythonProcess.killed) {
-        pythonProcess.kill('SIGTERM');
+        pythonProcess.kill("SIGTERM");
         setTimeout(() => {
           if (!pythonProcess.killed) {
-            pythonProcess.kill('SIGKILL');
+            pythonProcess.kill("SIGKILL");
           }
         }, 5000);
       }
     };
 
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
-    process.on('exit', cleanup);
+    process.on("SIGINT", cleanup);
+    process.on("SIGTERM", cleanup);
+    process.on("exit", cleanup);
 
     // Keep the wrapper alive
     await new Promise((resolve, reject) => {
-      pythonProcess.on('exit', resolve);
-      pythonProcess.on('error', reject);
+      pythonProcess.on("exit", resolve);
+      pythonProcess.on("error", reject);
     });
-
   } catch (error) {
-    console.error('Error in MCP server wrapper:', error);
+    console.error("Error in MCP server wrapper:", error);
     process.exit(1);
   }
 }
 
 // Start the wrapper
 main().catch((error) => {
-  console.error('Unhandled error:', error);
+  console.error("Unhandled error:", error);
   process.exit(1);
 });

--- a/setup-dev-env-with-evals.sh
+++ b/setup-dev-env-with-evals.sh
@@ -42,6 +42,15 @@ check_prerequisites() {
 setup_python() {
     echo "🐍 Setting up Python environment..."
 
+    # Create the project virtualenv if it doesn't exist yet, and install into
+    # it explicitly rather than whatever python3/pip happens to resolve on
+    # PATH (which may be a pyenv/Homebrew global with none of these deps).
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+        echo "✅ Created .venv"
+    fi
+    source .venv/bin/activate
+
     # Install Python dependencies
     pip install -e .[dev,test,monitoring]
     echo "✅ Python dependencies installed"

--- a/simplenote_mcp/server/server.py
+++ b/simplenote_mcp/server/server.py
@@ -2114,7 +2114,8 @@ async def _create_shutdown_monitor() -> asyncio.Future:
         while not shutdown_requested:
             await asyncio.sleep(0.1)
         logger.info("Shutdown requested, stopping server gracefully")
-        shutdown_future.set_result(None)
+        if not shutdown_future.done():
+            shutdown_future.set_result(None)
 
     asyncio.create_task(monitor_shutdown())
     return shutdown_future

--- a/test-ci-locally.sh
+++ b/test-ci-locally.sh
@@ -4,13 +4,14 @@ set -e
 echo "🧪 Testing CI/CD Steps Locally"
 echo "==============================="
 
-# Use the project virtualenv so this exercises the same python/pip/ruff/mypy
-# CI actually runs against, not whatever happens to be first on PATH.
-if [ ! -f .venv/bin/activate ]; then
-    echo "❌ .venv not found. Run ./setup-dev-env-with-evals.sh or 'python3 -m venv .venv && source .venv/bin/activate && pip install -e .[dev,test]' first."
-    exit 1
+# Prefer the project virtualenv so this exercises the same python/pip/ruff/mypy
+# a local dev machine uses, not whatever happens to be first on PATH. CI's own
+# "local-test" job runs this same script with no .venv (deps installed straight
+# into the runner's Python, same as Docker) — that's already correct, so this
+# is a no-op there.
+if [ -f .venv/bin/activate ]; then
+    source .venv/bin/activate
 fi
-source .venv/bin/activate
 
 echo ""
 echo "🔍 Step 1: Running diagnostics..."

--- a/test-ci-locally.sh
+++ b/test-ci-locally.sh
@@ -4,6 +4,14 @@ set -e
 echo "🧪 Testing CI/CD Steps Locally"
 echo "==============================="
 
+# Use the project virtualenv so this exercises the same python/pip/ruff/mypy
+# CI actually runs against, not whatever happens to be first on PATH.
+if [ ! -f .venv/bin/activate ]; then
+    echo "❌ .venv not found. Run ./setup-dev-env-with-evals.sh or 'python3 -m venv .venv && source .venv/bin/activate && pip install -e .[dev,test]' first."
+    exit 1
+fi
+source .venv/bin/activate
+
 echo ""
 echo "🔍 Step 1: Running diagnostics..."
 python .github/scripts/ci-diagnostics.py

--- a/test-mcp-evals.sh
+++ b/test-mcp-evals.sh
@@ -5,6 +5,13 @@
 
 set -e
 
+# Use the project virtualenv so the Python server subprocess (spawned by
+# mcp-server-wrapper.ts) sees its installed deps, not whatever python3
+# resolves to on PATH.
+if [ -f .venv/bin/activate ]; then
+    source .venv/bin/activate
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/tests/test_server_advanced.py
+++ b/tests/test_server_advanced.py
@@ -15,6 +15,7 @@ import pytest
 
 from simplenote_mcp.server.errors import ValidationError
 from simplenote_mcp.server.server import (
+    _create_shutdown_monitor,
     cleanup_pid_file,
     get_simplenote_client,
     handle_call_tool,
@@ -544,3 +545,46 @@ class TestResourceManagement:
             assert result.isError is True
             error_data = json.loads(result.content[0].text)
             assert "error" in error_data or "message" in error_data
+
+
+class TestShutdownMonitor:
+    """Regression test for the monitor_shutdown() already-done-future race."""
+
+    @pytest.mark.asyncio
+    async def test_monitor_shutdown_ignores_already_done_future(self):
+        """monitor_shutdown() must not raise if shutdown_future is already
+        resolved/cancelled by the time it notices shutdown_requested — this
+        raced during real SIGTERM teardown and logged an unretrieved
+        asyncio.InvalidStateError before the `.done()` guard was added.
+        """
+        tasks_before = asyncio.all_tasks()
+        shutdown_future = await _create_shutdown_monitor()
+        monitor_task = next(iter(asyncio.all_tasks() - tasks_before))
+
+        try:
+            # Simulate the future already being resolved via some other path
+            # before the background monitor task notices shutdown_requested.
+            shutdown_future.cancel()
+            server_module.shutdown_requested = True
+            # Awaiting the task re-raises any exception it hit internally —
+            # without the `.done()` guard this would raise InvalidStateError.
+            await asyncio.wait_for(monitor_task, timeout=1)
+        finally:
+            server_module.shutdown_requested = False
+
+        assert monitor_task.exception() is None
+        assert shutdown_future.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_monitor_shutdown_resolves_future_normally(self):
+        """Happy-path complement: when shutdown_future isn't already done,
+        monitor_shutdown() still resolves it once shutdown_requested flips
+        true — the `.done()` guard must not swallow the normal case.
+        """
+        shutdown_future = await _create_shutdown_monitor()
+        try:
+            server_module.shutdown_requested = True
+            result = await asyncio.wait_for(shutdown_future, timeout=1)
+            assert result is None
+        finally:
+            server_module.shutdown_requested = False


### PR DESCRIPTION
## Description
`mcp-server-wrapper.ts` spawned the MCP server via bare `spawn("python3", ...)`, which resolves to whatever's first on PATH (Homebrew/pyenv global) rather than this project's `.venv`. Since `mcp` and the rest of the runtime deps are only installed in `.venv`, every `npm run eval:*` invocation crashed immediately with `ModuleNotFoundError: No module named 'mcp'`, surfaced to the MCP client as a bare "Connection closed" — this was blocking every eval suite, not something new.

Also fixes a cosmetic shutdown race in `server.py`: `monitor_shutdown()` called `shutdown_future.set_result(None)` unconditionally, which raised an unretrieved `asyncio.InvalidStateError` if the future was already resolved/cancelled by the time SIGTERM teardown reached it.

## Changes
- `mcp-server-wrapper.ts`: prefer `.venv/bin/python3` when present, fall back to `python3` otherwise (CI/Docker without a local venv).
- `setup-dev-env-with-evals.sh`: create `.venv` if missing and install into it instead of bare `pip install`.
- `test-ci-locally.sh`: activate `.venv` up front, error clearly if missing.
- `test-mcp-evals.sh`: activate `.venv` if present before spawning the server.
- `docker-entrypoint.sh`: left as-is — confirmed the Docker image installs deps straight into its own system Python, no venv ambiguity there.
- `server.py`: guard `shutdown_future.set_result(None)` with `.done()`.
- `CHANGELOG.md`: documented both fixes under `[Unreleased] → Fixed`.

## Related Issue
N/A — found while validating a newly-added `ANTHROPIC_API_KEY` end-to-end via `npm run eval:comprehensive`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Full offline suite: `SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest tests/ -x -q --timeout=30` → 1334 passed, 8 skipped, 79.4% coverage
- [x] Legacy suite: `make test-legacy` → 112 passed, 9 skipped
- [x] `ruff check` / `mypy` clean on the changed Python file
- [x] `bash -n` syntax check on all three modified shell scripts
- [x] End-to-end: `npm run eval:comprehensive` ran to completion against the live Simplenote account with the fix in place — all 8 scenarios scored 4-5/5 by the LLM judge (previously crashed on server startup before the fix)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Summary by Sourcery

Ensure eval tooling and dev scripts consistently use the project virtualenv and harden server shutdown handling.

Bug Fixes:
- Make the MCP server wrapper prefer the project .venv Python interpreter to avoid missing dependencies during eval runs.
- Ensure local CI and MCP eval scripts run against the project .venv rather than whatever Python tools are on PATH.
- Prevent spurious asyncio.InvalidStateError by guarding shutdown_future.set_result with a completion check in the server shutdown monitor.

Enhancements:
- Document the virtualenv and shutdown behavior fixes in the changelog under the unreleased section.