### PR TITLE
fix: release.yml release_created output wiring and version bump gaps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       current_version: ${{ steps.get_version.outputs.current_version }}
       new_version: ${{ steps.bump_version.outputs.new_version }}
-      release_created: ${{ steps.create_release.outputs.release_created }}
+      release_created: ${{ steps.set_release_output.outputs.release_created }}
 
     steps:
       - name: Checkout code
@@ -93,7 +93,27 @@ jobs:
             if [ -f "simplenote_mcp/__init__.py" ]; then
               sed -i "s/__version__ = \".*\"/__version__ = \"$NEW_VERSION\"/g" simplenote_mcp/__init__.py
             fi
+
+            # Update version in VERSION
+            if [ -f "VERSION" ]; then
+              echo "$NEW_VERSION" > VERSION
+            fi
+
+            # Update version in the Helm chart
+            if [ -f "helm/simplenote-mcp-server/Chart.yaml" ]; then
+              sed -i "s/^version: .*/version: $NEW_VERSION/" helm/simplenote-mcp-server/Chart.yaml
+              sed -i "s/^appVersion: .*/appVersion: \"$NEW_VERSION\"/" helm/simplenote-mcp-server/Chart.yaml
+            fi
+
+            # Update version in setup.py (legacy fallback, kept in sync manually)
+            if [ -f "setup.py" ]; then
+              sed -i "s/version=\".*\"/version=\"$NEW_VERSION\"/" setup.py
+            fi
           fi
+
+      - name: Verify version consistency
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: python scripts/quality/check_version_consistency.py
 
       - name: Generate changelog
         id: changelog
@@ -101,9 +121,9 @@ jobs:
         run: |
           # Get last tag for changelog generation
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          
+
           echo "Generating changelog using conventional commit parser..."
-          
+
           # Use the conventional changelog script
           if [ -n "$LAST_TAG" ]; then
             echo "Generating changelog since $LAST_TAG"
@@ -141,7 +161,13 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add pyproject.toml simplenote_mcp/__init__.py changelog.md || true
+          # changelog.md is intentionally NOT committed here — it's an
+          # auto-generated conventional-commits dump used only for the
+          # GitHub Release body and the changelog-<version> artifact.
+          # Committing it collides with CHANGELOG.md (the real, hand-curated
+          # changelog) on case-insensitive filesystems (macOS/Windows).
+          git add pyproject.toml simplenote_mcp/__init__.py VERSION \
+            helm/simplenote-mcp-server/Chart.yaml setup.py || true
           git commit -m "Bump version to ${{ steps.bump_version.outputs.new_version }}" || echo "No changes to commit"
           git tag -a v${{ steps.bump_version.outputs.new_version }} -m "Version ${{ steps.bump_version.outputs.new_version }}"
           echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
@@ -173,6 +199,7 @@ jobs:
           retention-days: 30
 
       - name: Set release creation output
+        id: set_release_output
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: echo "release_created=true" >> $GITHUB_OUTPUT
 
@@ -183,7 +210,7 @@ jobs:
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+      id-token: write # required for PyPI Trusted Publishing (OIDC)
 
     steps:
       - name: Check out code
@@ -214,23 +241,23 @@ jobs:
       - name: Generate SBOM and vulnerability report
         run: |
           echo "📋 Generating SBOM and vulnerability reports for release..."
-          
+
           # Install required tools
           pip install cyclonedx-bom==7.0.0 pip-audit==2.7.3
-          
+
           # Generate vulnerability report
           echo "🔍 Generating vulnerability report..."
           pip-audit -r pyproject.toml -f json -o vulnerability-report.json || true
           pip-audit -r pyproject.toml -f markdown -o vulnerability-report.md || true
-          
+
           # Generate SBOM in multiple formats
           echo "📋 Generating Software Bill of Materials..."
           cyclonedx-py -o sbom-release.json -F json --install-all-packages
           cyclonedx-py -o sbom-release.xml -F xml --install-all-packages
-          
+
           # Generate additional SBOM from pip-audit
           pip-audit -r pyproject.toml -f cyclonedx-json -o sbom-pip-audit-release.json || true
-          
+
           # Generate release-specific simple SBOM
           echo "📋 Generating release SBOM..."
           python - <<'EOF'
@@ -238,7 +265,7 @@ jobs:
           import subprocess
           import sys
           from datetime import datetime
-          
+
           def get_package_info():
               """Get installed package information."""
               try:
@@ -250,7 +277,7 @@ jobs:
               except Exception as e:
                   print(f"Error getting package info: {e}")
                   return []
-          
+
           # Generate release SBOM with version info
           packages = get_package_info()
           sbom = {
@@ -276,7 +303,7 @@ jobs:
               },
               "components": []
           }
-          
+
           # Add components
           for package in packages:
               component = {
@@ -287,19 +314,19 @@ jobs:
                   "scope": "required"
               }
               sbom["components"].append(component)
-          
+
           with open('sbom-release-simple.json', 'w') as f:
               json.dump(sbom, f, indent=2)
-          
+
           print(f"Generated SBOM with {len(sbom['components'])} components")
           EOF
-          
+
           # Create vulnerability summary
           echo "📊 Creating vulnerability summary..."
           python - <<'EOF'
           import json
           import os
-          
+
           try:
               with open('vulnerability-report.json', 'r') as f:
                   report = json.load(f)
@@ -367,11 +394,11 @@ jobs:
               with open('vulnerability-summary.json', 'w') as f:
                   json.dump(summary, f, indent=2)
           EOF
-          
+
           # List generated files
           echo "📋 Generated files:"
           ls -la sbom-*.json sbom-*.xml vulnerability-*.json vulnerability-*.md 2>/dev/null || true
-          
+
           echo "✅ SBOM and vulnerability report generation completed"
 
       - name: Upload SBOM and vulnerability artifacts
@@ -414,7 +441,7 @@ jobs:
         run: |
           echo "📋 Downloaded security reports:"
           ls -la security-reports/
-          
+
       - name: Attach SBOM and vulnerability reports to release
         uses: softprops/action-gh-release@c12583777ecdfd3be55c69cf75464299dc01057e # v3
         with:


### PR DESCRIPTION
## Description
Two bugs found while auditing why the `v1.17.2` release run silently skipped publishing and left `VERSION`/`Chart.yaml`/`setup.py` stale (fixed manually in #706).

1. **`release_created` output wiring**: `prepare-release`'s job output read `steps.create_release.outputs.release_created`, but `create_release` (`softprops/action-gh-release`) has no such output — the actual `echo "release_created=true"` ran in a separate step with no `id:`. The job output was therefore always empty, so `build-and-publish`/`attach-security-reports`/`notify` were silently skipped on **every** release run, not just the last one. Fixed by giving that step `id: set_release_output` and pointing the job output at it.

2. **Version bump gaps**: the "Bump version" step only ever updated `pyproject.toml` and `simplenote_mcp/__init__.py`, never `VERSION`, `helm/simplenote-mcp-server/Chart.yaml`, or `setup.py`. Now updates all five sources and runs `scripts/quality/check_version_consistency.py` as a safety net before committing/pushing, so future drift fails loudly instead of landing silently on `main`.

Also stops committing the auto-generated `changelog.md` to the repo (removed from the `git add` list) — still generated for the GitHub Release body and `changelog-<version>` artifact, just never committed. Committing it collided with `CHANGELOG.md` (the real, hand-curated changelog) on case-insensitive filesystems (macOS/Windows): pulling a release commit silently overwrote one file with the other's content on disk. **The already-committed `changelog.md` file itself still needs manual removal from the repo — not done in this PR**, flagged separately for a decision on approach.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] `actionlint` on the modified file reports the same pre-existing shellcheck warnings as the original (none new)
- [x] Dry-ran the new `VERSION`/`Chart.yaml`/`setup.py` sed/echo logic against copies of the real files — all three update correctly
- [x] Full test suite: 1336 passed, 8 skipped (no Python source touched)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Summary by Sourcery

Fix release workflow so downstream jobs run only when a release is actually created and ensure version bumps are fully consistent across all version sources.

Bug Fixes:
- Wire the release_created job output to the correct step so build, security reports, and notification jobs no longer get silently skipped.
- Include VERSION, Helm Chart.yaml, and setup.py in the automated version bump to prevent version drift across release artifacts.
- Stop committing the auto-generated changelog.md to avoid collisions with the curated CHANGELOG.md on case-insensitive filesystems.

Enhancements:
- Add a version consistency check script to the release workflow to validate all version sources before committing and tagging.