### PR TITLE
fix: release.yml SBOM generation — pinned dependency conflict + CLI change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,8 +242,13 @@ jobs:
         run: |
           echo "📋 Generating SBOM and vulnerability reports for release..."
 
-          # Install required tools
-          pip install cyclonedx-bom==7.0.0 pip-audit==2.7.3
+          # Install required tools. These two must stay mutually compatible
+          # on cyclonedx-python-lib (cyclonedx-bom==7.0.0 required >=8,<11;
+          # pip-audit==2.7.3 required >=5,<8 — no overlap, so this step
+          # always failed with ResolutionImpossible). Verified compatible as
+          # of 2026-07-16: cyclonedx-bom 7.3.0 -> cyclonedx-python-lib 11.x,
+          # pip-audit 2.10.1 -> cyclonedx-python-lib <11 too.
+          pip install cyclonedx-bom==7.3.0 pip-audit==2.10.1
 
           # Generate vulnerability report
           echo "🔍 Generating vulnerability report..."
@@ -252,8 +257,11 @@ jobs:
 
           # Generate SBOM in multiple formats
           echo "📋 Generating Software Bill of Materials..."
-          cyclonedx-py -o sbom-release.json -F json --install-all-packages
-          cyclonedx-py -o sbom-release.xml -F xml --install-all-packages
+          # cyclonedx-bom 7.x replaced the flat `-F`/`--install-all-packages`
+          # flags with a subcommand-based CLI; `environment` scans the
+          # current (virtual) environment, equivalent to the old default.
+          cyclonedx-py environment -o sbom-release.json --of JSON
+          cyclonedx-py environment -o sbom-release.xml --of XML
 
           # Generate additional SBOM from pip-audit
           pip-audit -r pyproject.toml -f cyclonedx-json -o sbom-pip-audit-release.json || true


### PR DESCRIPTION
## Description
Two more bugs found running the release workflow end-to-end (the `v1.17.4` attempt failed here, after the output-wiring/version-bump/changelog.md fixes in #706/#707/#708 all worked correctly).

1. **Pinned dependency conflict**: `cyclonedx-bom==7.0.0` requires `cyclonedx-python-lib>=8,<11`; `pip-audit==2.7.3` requires `cyclonedx-python-lib>=5,<8` — no overlap, so `pip install cyclonedx-bom==7.0.0 pip-audit==2.7.3` has never been installable (`ResolutionImpossible`). This has silently blocked `Publish to PyPI` on every release run that got this far. Bumped to `cyclonedx-bom==7.3.0` + `pip-audit==2.10.1`, verified mutually installable.

2. **CLI breaking change**: `cyclonedx-bom` 7.x replaced the old flat `cyclonedx-py -o <file> -F <format> --install-all-packages` CLI with a subcommand-based one — those flags no longer exist. Updated both invocations to `cyclonedx-py environment -o <file> --of <FORMAT>`, verified against a real venv (valid JSON with correct component count, valid XML).

Left the `pip-audit -r pyproject.toml ...` calls untouched — pre-existing (unrelated to either pin) and already tolerated via `|| true` in the script, so it doesn't block the step.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Verified `cyclonedx-bom==7.3.0` + `pip-audit==2.10.1` install together cleanly in a fresh venv
- [x] Verified the new `cyclonedx-py environment -o ... --of ...` invocations produce valid JSON/XML output
- [x] `actionlint` reports the same pre-existing shellcheck warnings as before (none new)
- [x] Full test suite: 1336 passed, 8 skipped (no Python source touched)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## Summary by Sourcery

Resolve SBOM generation failures in the release workflow by updating dependency pins and adapting to the new cyclonedx CLI.

Bug Fixes:
- Update cyclonedx-bom and pip-audit versions in the release workflow to use a mutually compatible cyclonedx-python-lib dependency range.
- Adjust SBOM generation commands to the new cyclonedx-py subcommand-based CLI so the release workflow can successfully produce JSON and XML SBOMs.