### PR TITLE
fix(ci): remove dead-end PyPI publish step from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,12 +205,10 @@ jobs:
 
   build-and-publish:
     timeout-minutes: 10
-    name: Build and Publish Package
+    name: Build Package and Generate Security Reports
     needs: prepare-release
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write # required for PyPI Trusted Publishing (OIDC)
 
     steps:
       - name: Check out code
@@ -420,17 +418,6 @@ jobs:
             vulnerability-*.md
           retention-days: 90
 
-      - name: Publish to PyPI
-        if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          skip-existing: false
-
-      - name: Post-publish summary
-        if: ${{ github.event.inputs.dry_run != 'true' }}
-        run: |
-          echo "Publish step executed. Verify on PyPI to confirm success."
-
   attach-security-reports:
     timeout-minutes: 5
     name: Attach Security Reports to Release
@@ -474,11 +461,11 @@ jobs:
       - name: Send success notification
         if: ${{ needs.build-and-publish.result == 'success' }}
         run: |
-          echo "Version ${{ needs.prepare-release.outputs.new_version }} was successfully released!"
+          echo "Version ${{ needs.prepare-release.outputs.new_version }} tagged and built. Run publish-pypi.yml to publish to PyPI."
           # Add notification mechanism here if needed (Slack, email, etc.)
 
       - name: Send failure notification
         if: ${{ needs.build-and-publish.result != 'success' }}
         run: |
-          echo "Release process failed at the build/publish stage."
+          echo "Release process failed at the build stage."
           # Add notification mechanism here if needed (Slack, email, etc.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invalid configuration (a bad `MCP_TRANSPORT` value, missing credentials outside offline mode,
   etc.) now fails fast at startup with a clear message instead of surfacing later, less clearly,
   during client/cache initialization.
+- **`release.yml`'s `Publish to PyPI` step could never succeed**, blocking every release from
+  v1.17.1 through v1.17.4 from ever reaching PyPI: PyPI's Trusted Publisher for this project is
+  registered against the separate `publish-pypi.yml` workflow, not `release.yml`, so its OIDC
+  token exchange was always rejected with `invalid-publisher`. `release.yml` still tags, builds,
+  and generates SBOM/vulnerability reports on every dispatch; publishing to PyPI is now solely
+  `publish-pypi.yml`'s job (`gh workflow run publish-pypi.yml -f tag=vX.Y.Z`), which has the
+  correct Trusted Publisher registration and has published successfully since 2026-04-30.
+  (Also fixed separately: `cyclonedx-bom==7.0.0` + `pip-audit==2.7.3` had conflicting
+  `cyclonedx-python-lib` requirements, failing the SBOM generation step itself before this bug
+  was even reachable — pinned to `cyclonedx-bom==7.3.0` + `pip-audit==2.10.1`.)
 
 ### Changed
 - Declared JSON schema for `tags` unified to `array<string>` across all tag-accepting tools


### PR DESCRIPTION
## Summary
- `release.yml`'s `Publish to PyPI` step could never succeed — PyPI's Trusted Publisher for this project is registered against `publish-pypi.yml`, not `release.yml`, so every OIDC token exchange was rejected with `invalid-publisher`
- This silently blocked v1.17.1 through v1.17.4 from ever reaching PyPI, even though each was tagged and GitHub-released normally
- `release.yml` now stops after tagging, building, and generating SBOM/vulnerability reports; `publish-pypi.yml` (correctly registered, working since 2026-04-30) is the sole PyPI publish path — invoke via `gh workflow run publish-pypi.yml -f tag=vX.Y.Z` after a release is cut

## Test plan
- [x] `actionlint` clean on the modified job (pre-existing shellcheck notes elsewhere are unrelated to this change)
- [x] Verified locally: v1.17.5 is live on PyPI via `publish-pypi.yml`, confirming that workflow's Trusted Publisher config is correct
- [x] Pre-commit hooks pass (mypy, whitespace, etc.)
- [ ] Next `release.yml` dispatch should complete `build-and-publish` and `attach-security-reports` without the prior `invalid-publisher` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify the release workflow so that it only handles tagging, building, and security report generation, and delegate PyPI publishing exclusively to the dedicated publish-pypi workflow.

CI:
- Remove the non-functional PyPI publish step and associated OIDC permissions from release.yml, leaving it as a build and security-report workflow only.
- Update release success/failure messages to instruct maintainers to run publish-pypi.yml for PyPI publishing and to reflect that failures now occur only at the build stage.

Documentation:
- Add changelog notes explaining that prior releases failed to reach PyPI due to a misconfigured Trusted Publisher workflow and documenting the corrected publishing process via publish-pypi.yml.