### PR TITLE
docs: install DOX hierarchical AGENTS.md tree

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,29 @@
+# .github/workflows/
+
+## Purpose
+
+CI/CD pipeline definitions. `unified-ci.yml` is the main pipeline (validate → test → security → status jobs); `release.yml` is manual-dispatch-only (see root `AGENTS.md`); others handle Dependabot automation, security scanning, docs, and evaluations.
+
+## Ownership
+
+- `unified-ci.yml` — `validate` (version consistency, lint), `test`, `security`, `local-test`, `status` jobs; blocks on version consistency before test/build/security run.
+- `security.yml`, `dependency-review.yml` — Bandit/pip-audit/CodeQL-style scanning.
+- `auto-fix.yml`, `auto-merge.yml`, `claude-dependabot-merge.yml`, `claude-status-check.yml` — Dependabot/PR automation.
+- `evaluation-quality-gate.yml`, `mcp-evaluations.yml` — mcp-evals suite runners; both gate on `ANTHROPIC_API_KEY` presence so Dependabot PRs (no repo secret access) skip gracefully instead of failing.
+- `release.yml` — manual `workflow_dispatch` version bump/release (patch/minor/major). `update-version.yml` — triggers on `v*.*.*` tag push, syncs version references post-release.
+- `docs.yml`, `monitoring-consolidated.yml`, `publish-pypi.yml` — docs build, consolidated monitoring checks, PyPI publish.
+
+## Local Contracts
+
+- **`yaml.safe_load()` is not sufficient to validate `uses:` lines.** A YAML-valid-but-schema-invalid `uses:` value (e.g. a bare SHA with the tag comment misplaced, instead of `owner/repo@<sha> # tag`) parses cleanly but makes GitHub run **zero jobs** for every workflow referencing it. Only a schema-aware linter (`actionlint`) catches this class of bug — not currently run in CI. Run `actionlint` on any `.github/workflows/*.yml` edit before considering it done, especially SHA-pinning changes.
+- **`github-script` steps must pass untrusted values via `env:`**, never interpolate `${{ needs.*.outputs.* }}` / `${{ github.event.inputs.* }}` / `${{ steps.*.outputs.* }}` directly into the `script:` body — an injected value could break out of the JS string literal (script-injection). Read via `process.env.*` instead; see the existing pattern and comment in `auto-fix.yml`.
+- `dependabot.yml` (one directory up, at `.github/dependabot.yml`) covers four ecosystems: `pip`, `npm`, `docker`, `github-actions` — keep all four current when adding a new dependency manager to the project.
+
+## Verification
+
+- `actionlint` on any changed workflow file (manual — not yet wired into CI itself)
+- Push/PR and watch the `validate` job in `unified-ci.yml` actually queues and runs
+
+## Child DOX Index
+
+None.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,170 @@
+# simplenote-mcp-server
+
+MCP server connecting Simplenote to Claude Desktop and other MCP clients. Python ≥3.10, package root `simplenote_mcp/`.
+
+## Commands
+
+```bash
+# Setup
+pip install -e ".[dev,test,all]"
+pre-commit install
+
+# Tests — two independent trees, run separately (see tests/AGENTS.md and simplenote_mcp/tests/AGENTS.md for why)
+make test-fast      # SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest tests/ -x -q --timeout=30
+make test-legacy    # SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest simplenote_mcp/tests/ -q --timeout=30 --no-cov
+make test           # both, via .venv/bin/pytest -q (root testpaths = tests/ only; legacy run separately in CI)
+
+# Quality
+ruff check .
+ruff format .
+mypy simplenote_mcp
+bandit -c pyproject.toml -r simplenote_mcp   # always pass -c; bare invocation misapplies exclude_dirs
+
+# Evaluations (npm devDependency tree, never shipped — see package.json)
+npm install && npm run eval:smoke   # eval:basic, eval:comprehensive, eval:all also available
+```
+
+Always invoke `.venv/bin/pytest` / `.venv/bin/ruff` / `.venv/bin/mypy` / `.venv/bin/bandit` explicitly, or prefix with `source .venv/bin/activate &&` in the same shell call — each Bash invocation is a fresh shell, so a prior `activate` does not persist and bare commands silently resolve through the pyenv shim to the global environment instead of `.venv`.
+
+## Architecture
+
+```text
+simplenote_mcp/
+├── server/            # MCP protocol handlers, tool registry, cache, security — see server/AGENTS.md
+│   ├── search/         # Query parser + boolean/fuzzy/date search engine — see server/search/AGENTS.md
+│   └── monitoring/      # Metrics collection + alerting thresholds — see server/monitoring/AGENTS.md
+├── scripts/            # Runtime diagnostics shipped with the package — see simplenote_mcp/scripts/AGENTS.md
+├── tests/               # Legacy pytest tree, separate invocation — see simplenote_mcp/tests/AGENTS.md
+└── __main__.py         # Entry point (module execution)
+tests/                  # Primary CI-wired pytest tree — see tests/AGENTS.md
+scripts/                # CI/quality/release tooling — see scripts/AGENTS.md
+helm/                   # Helm chart — see helm/AGENTS.md
+.github/workflows/      # CI/CD pipelines — see .github/workflows/AGENTS.md
+docs/, evals/           # Reference docs and mcp-evals suites; no durable local contracts of their own
+```
+
+### Design patterns
+
+- **Tool Handler Registry**: each tool (`create_note`, `search_notes`, etc.) is a `ToolHandlerBase` subclass registered in `ToolHandlerRegistry` (`server/tool_handlers.py`).
+- **Middleware chain**: security validation, input validation, and rate limiting applied via decorators (`server/decorators.py`, `server/middleware.py`) before a handler runs.
+- **Background sync**: `NoteCache` (`server/cache.py`) syncs from Simplenote in a background thread so tool calls stay responsive.
+- **Error hierarchy**: custom exceptions in `server/errors.py` / `server/error_taxonomy.py` carry MCP-appropriate error codes and user-facing messages.
+
+## Local Contracts
+
+- **Version consistency**: four files must carry the same version — `VERSION`, `pyproject.toml`, `simplenote_mcp/__init__.py`, `helm/simplenote-mcp-server/Chart.yaml` (`appVersion`). `setup.py` also has a version string, now checked as a legacy fallback by `scripts/quality/check_version_consistency.py`. Never bump manually outside the release workflow.
+- **Release process is manual, not automatic**: `.github/workflows/release.yml` runs only on `workflow_dispatch` (explicit bump-type input). No workflow triggers a release from a conventional-commit push to `main` — merging a `docs:`/`feat:`/`fix:` PR never cuts a release by itself.
+- **Write-mode gate**: any tool that mutates Simplenote data must be added to the `WRITE_TOOLS` frozenset in `server/server.py` or it bypasses the write-mode/write-budget gate — see `server/AGENTS.md`.
+- **Bandit config**: `[tool.bandit]` in `pyproject.toml` is authoritative; the separate `.bandit` YAML file disagrees on skipped checks and must not be used. Always run with `-c pyproject.toml`.
+- **No credentials, tokens, or Simplenote account data** in any AGENTS.md, doc, script output, or committed fixture, ever.
+
+## Work Guidance
+
+- Read the nearest child `AGENTS.md` for the folder you're editing before making changes; this root file covers only repo-wide rules.
+- Extract conventions from existing code — do not invent patterns not already present.
+- Update the owning `AGENTS.md` (and any Child DOX Index) whenever you change structure, contracts, or workflow — see the DOX framework block below.
+
+## Verification
+
+- `make test-fast` and `make test-legacy` (both must pass; do not merge into one invocation — see `tests/AGENTS.md`)
+- `ruff check . && ruff format --check .`
+- `mypy simplenote_mcp`
+- `bandit -c pyproject.toml -r simplenote_mcp`
+- `python scripts/quality/check_version_consistency.py`
+
+---
+
+## DOX framework
+
+- DOX is highly performant AGENTS.md hierarchy installed here
+- Agent must follow DOX instructions across any edits
+
+### Core Contract
+
+- AGENTS.md files are binding work contracts for their subtrees
+- Work products, source materials, instructions, records, assets, and durable docs must stay understandable from the nearest applicable AGENTS.md plus every parent AGENTS.md above it
+
+### Read Before Editing
+
+1. Read the root AGENTS.md
+2. Identify every file or folder you expect to touch
+3. Walk from the repository root to each target path
+4. Read every AGENTS.md found along each route
+5. If a parent AGENTS.md lists a child AGENTS.md whose scope contains the path, read that child and continue from there
+6. Use the nearest AGENTS.md as the local contract and parent docs for repo-wide rules
+7. If docs conflict, the closer doc controls local work details, but no child doc may weaken DOX
+
+Do not rely on memory. Re-read the applicable DOX chain in the current session before editing.
+
+### Update After Editing
+
+Every meaningful change requires a DOX pass before the task is done.
+
+Update the closest owning AGENTS.md when a change affects:
+
+- purpose, scope, ownership, or responsibilities
+- durable structure, contracts, workflows, or operating rules
+- required inputs, outputs, permissions, constraints, side effects, or artifacts
+- user preferences about behavior, communication, process, organization, or quality
+- AGENTS.md creation, deletion, move, rename, or index contents
+
+Update parent docs when parent-level structure, ownership, workflow, or child index changes. Update child docs when parent changes alter local rules. Remove stale or contradictory text immediately. Small edits that do not change behavior or contracts may leave docs unchanged, but the DOX pass still must happen.
+
+### Hierarchy
+
+- Root AGENTS.md is the DOX rail: project-wide instructions, global preferences, durable workflow rules, and the top-level Child DOX Index
+- Child AGENTS.md files own domain-specific instructions and their own Child DOX Index
+- Each parent explains what its direct children cover and what stays owned by the parent
+- The closer a doc is to the work, the more specific and practical it must be
+
+### Child Doc Shape
+
+- Create a child AGENTS.md when a folder becomes a durable boundary with its own purpose, rules, responsibilities, workflow, materials, or quality standards
+- Work Guidance must reflect the current standards of the project or user instructions; if there are no specific standards or instructions yet, leave it empty
+- Verification must reflect an existing check; if no verification framework exists yet, leave it empty and update it when one exists
+
+Default section order:
+
+- Purpose
+- Ownership
+- Local Contracts
+- Work Guidance
+- Verification
+- Child DOX Index
+
+### Style
+
+- Keep docs concise, current, and operational
+- Document stable contracts, not diary entries
+- Put broad rules in parent docs and concrete details in child docs
+- Prefer direct bullets with explicit names
+- Do not duplicate rules across many files unless each scope needs a local version
+- Delete stale notes instead of explaining history
+- Trim obvious statements, repeated rules, misplaced detail, and warnings for risks that no longer exist
+
+### Closeout
+
+1. Re-check changed paths against the DOX chain
+2. Update nearest owning docs and any affected parents or children
+3. Refresh every affected Child DOX Index
+4. Remove stale or contradictory text
+5. Run existing verification when relevant
+6. Report any docs intentionally left unchanged and why
+
+### User Preferences
+
+- Never bump versions manually; the release workflow (`workflow_dispatch` only) owns version bumps across all four version-source files.
+- Never include `[skip ci]` in commits.
+- Always run the full test suite (both trees) after source changes; do not mark work done with failing tests.
+
+### Child DOX Index
+
+- `simplenote_mcp/server/AGENTS.md` — core server package: protocol handlers, tool registry, cache, security, credentials, vault encryption
+- `simplenote_mcp/server/search/AGENTS.md` — query parser and boolean/fuzzy/date search engine
+- `simplenote_mcp/server/monitoring/AGENTS.md` — metrics collection and alerting thresholds
+- `simplenote_mcp/scripts/AGENTS.md` — runtime diagnostics scripts shipped inside the package
+- `simplenote_mcp/tests/AGENTS.md` — legacy pytest tree (112 tests, separate invocation)
+- `tests/AGENTS.md` — primary CI-wired pytest tree
+- `scripts/AGENTS.md` — CI/quality/release tooling (not shipped)
+- `helm/AGENTS.md` — Helm chart for Kubernetes deployment
+- `.github/workflows/AGENTS.md` — CI/CD pipeline definitions

--- a/helm/AGENTS.md
+++ b/helm/AGENTS.md
@@ -1,0 +1,26 @@
+# helm/
+
+## Purpose
+
+Helm chart for deploying `simplenote-mcp-server` to Kubernetes (`helm/simplenote-mcp-server/`).
+
+## Ownership
+
+- `Chart.yaml` — chart metadata; `version` and `appVersion` must track the project version (see Local Contracts).
+- `values.yaml` — defaults (replica count, image repo/tag, security context, resources).
+- `templates/` — `deployment.yaml`, `service.yaml`, `serviceaccount.yaml`, `configmap.yaml`, `secret.yaml` (renders `SIMPLENOTE_PASSWORD` from `.Values.simplenote.password`, base64-encoded — never hardcode a real password in `values.yaml`), `hpa.yaml`, `_helpers.tpl`.
+
+## Local Contracts
+
+- `Chart.yaml`'s `appVersion` is one of the four files checked by `scripts/quality/check_version_consistency.py` (alongside `VERSION`, `pyproject.toml`, `simplenote_mcp/__init__.py`) — keep it in sync; never bump manually outside the release workflow.
+- `values.yaml`'s `image.tag` is **not** covered by `check_version_consistency.py` or `scripts/validate-helm.py` (the latter only checks `values.yaml` for security settings) — it can silently drift behind `Chart.yaml`'s `appVersion`. Check it manually when bumping versions.
+- No real credentials in `values.yaml` or any committed values file — `secret.yaml` expects `.Values.simplenote.password` to be supplied at install time (`--set` or a separate, untracked values file).
+
+## Verification
+
+- `python scripts/validate-helm.py`
+- `helm lint helm/simplenote-mcp-server`
+
+## Child DOX Index
+
+None.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,30 @@
+# scripts/
+
+## Purpose
+
+CI, quality-gate, and release tooling — not shipped in the package or Docker image (devDependency-equivalent for Python: dev-only, invoked by CI workflows, Makefile, and pre-commit, never imported by `simplenote_mcp/`).
+
+## Ownership
+
+- `quality/` — CI "Validate" job checks: `check_version_consistency.py` (VERSION/pyproject.toml/`simplenote_mcp/__init__.py`/Chart.yaml/setup.py must match), `check_coverage.py`, `check_complexity.py` (Radon), `archive_old_docs.py`.
+- `run-quality-checks.py`, `run-comprehensive-tests.py`, `test-categories.py` — local aggregate quality/test runners (mirror CI locally).
+- `validate-*.py` (workflows, badges, CI/CD health/pipeline, Helm, version-pinning, offline) — CI/config validators, mostly read-only.
+- `conventional_changelog.py` — parses conventional-commit history into changelog sections; used by `release.yml`.
+- `manage-prs.py`, `resolve-prs-offline.py`, `check-workflow-status.py`, `verify-github-status.py` — GitHub API tooling for solo-maintainer PR/workflow triage; `--merge`/`--close` operations are destructive (merge/close real PRs) and require explicit invocation, never run unattended.
+- `update-dockerhub-readme.py`/`.sh` — pushes repository description to Docker Hub via `DOCKER_USERNAME`/`DOCKER_TOKEN`; external side effect, requires credentials.
+- `add-timeouts-to-workflows.py` — one-off workflow-mutation helper; review its diff before trusting output on new workflows.
+- `claude-code-support/` — Claude Code hook/assistant scripts (`auto-test.sh` etc.), not part of the CI pipeline.
+
+## Local Contracts
+
+- Scripts here are **dev/CI-only** — never import from this directory in `simplenote_mcp/`, and never bundle it into the Docker image or PyPI package.
+- `manage-prs.py --merge`/`--close` and any Docker Hub push script have real external side effects (merges/closes GitHub PRs, updates a public Docker Hub listing) — confirm with the user before running, same as any other hard-to-reverse action.
+
+## Verification
+
+- `python scripts/quality/check_version_consistency.py`
+- `python scripts/run-quality-checks.py`
+
+## Child DOX Index
+
+None — `quality/` is a thin sub-boundary covered above, not large enough for its own doc.

--- a/simplenote_mcp/scripts/AGENTS.md
+++ b/simplenote_mcp/scripts/AGENTS.md
@@ -1,0 +1,28 @@
+# simplenote_mcp/scripts/
+
+## Purpose
+
+Runtime diagnostics and dev-workflow scripts shipped alongside the package (distinct from top-level `scripts/`, which is CI/quality tooling only). See `README.md` in this folder for per-script usage.
+
+## Ownership
+
+- Server management: `restart_claude.sh`, `cleanup_servers.sh`, `check_server_pid.sh`, `watch_logs.sh` — operate on the locally running Claude Desktop / MCP server process.
+- Diagnostics: `diagnose_api.py` (Simplenote API connectivity), `analyze_logs.py`, `log_format_test.py`, `logging_examples.py`, `error_examples.py`, `monitoring_dashboard.py` (terminal UI for `server/monitoring/metrics.py`).
+- Test/coverage helpers: `generate_test_coverage.py`, `live_test_redesign.py`.
+- Verification: `verify_tools.sh`, `test_tool_visibility.sh` — confirm tools are registered and visible to Claude.
+- `release.sh` — bumps version and tags a release; refuses to run with a dirty working tree.
+- `config.sh` — shared shell config sourced by the `.sh` scripts here.
+
+## Local Contracts
+
+- `restart_claude.sh` and `cleanup_servers.sh` kill running processes (Claude Desktop / MCP server) — confirm with the user before running against a session with unsaved state elsewhere.
+- `release.sh` tags and can push a release; it is a manual, deliberate action, not something to run as a side effect of an unrelated task.
+- These scripts assume a local macOS Claude Desktop installation (paths, `restart_claude.sh` process names) — not portable CI tooling.
+
+## Verification
+
+None — these are interactive/manual diagnostic tools, not part of the automated test suite.
+
+## Child DOX Index
+
+None.

--- a/simplenote_mcp/server/AGENTS.md
+++ b/simplenote_mcp/server/AGENTS.md
@@ -1,0 +1,43 @@
+# simplenote_mcp/server/
+
+## Purpose
+
+Core MCP server package: protocol handlers, tool registry, note cache, credential resolution, security/rate-limit middleware, and opt-in vault encryption. Flat file layout — no further nesting except `search/` and `monitoring/` (own child docs) and `compat/`/`utils/` (small, covered here).
+
+## Ownership
+
+- `server.py` — MCP protocol handlers (`handle_list_tools`, `handle_call_tool`, etc.), Simplenote client singleton, `WRITE_TOOLS` gate, write-budget tracking, background cache init.
+- `tool_handlers.py` — one `ToolHandlerBase` subclass per tool, registered in `ToolHandlerRegistry`.
+- `cache.py` — `NoteCache`: in-memory cache, background sync, search indexing. `cache_utils.py` — cache helper functions; note its `CacheManager.get_or_create_note` method (see Local Contracts) is dead code, not the live tool path.
+- `config.py` — environment-based `Config` singleton (`SIMPLENOTE_EMAIL`/`SIMPLENOTE_PASSWORD`, `SIMPLENOTE_OFFLINE_MODE`, `SYNC_INTERVAL_SECONDS`, `LOG_LEVEL`, write-budget settings, HTTP transport settings).
+- `security.py` — `validate_tool_security` decorator and input validators. `middleware.py` — `RateLimiter`, `RequestValidator`, `AuthenticationMiddleware`. `decorators.py` — composes these onto handlers.
+- `errors.py` / `error_codes.py` / `error_helpers.py` / `error_taxonomy.py` — exception hierarchy and MCP-facing error formatting.
+- `auth.py` / `keychain.py` — Simperium token resolution (see Local Contracts).
+- `vault.py` — opt-in client-side AES-256-GCM note encryption (`encrypt_note`/`decrypt_note`/`vault_status` tools).
+- `logging.py` / `logger_factory.py` / `log_monitor.py` / `alerting.py` / `memory_monitor.py` — structured logging, log tailing, threshold alerting.
+- `duplicates.py`, `export.py`, `http_endpoints.py`, `context.py`, `mcp_types_compat.py` — single-purpose support modules.
+- `compat/`, `utils/` — small compatibility shims and shared helpers (content-type detection, common utilities); no independent rules beyond this doc.
+
+## Local Contracts
+
+- **Tool-handler pattern**: adding a tool touches three places — the `XHandler(ToolHandlerBase)` class in `tool_handlers.py`, one line in `ToolHandlerRegistry._handlers`, and a `types.Tool(...)` schema entry in `server.py::handle_list_tools()`. Any handler that mutates Simplenote data must also be added to the `WRITE_TOOLS` frozenset in `server.py`, or it bypasses both the `SIMPLENOTE_WRITE_MODE` gate and the per-client write-budget check (`_check_write_budget`/`_record_write`).
+- **Credential resolution** (`keychain.py::get_simperium_token`): local file cache at `~/.config/simplenote-mcp/<email>.token` (mode `0600`, `os.open(..., mode=0o600)` for atomic restrictive creation — never write-then-chmod) → macOS Keychain entry used by Simplenote Desktop (`chalk-bump-f49`) → password fallback in `server.py::_test_simplenote_connection()`. No note-content encryption exists outside the opt-in Vault feature; Simplenote itself has no encryption at rest.
+- **`cache_utils.py::CacheManager.get_or_create_note` is dead code**: it calls the synchronous `sn.get_note()` directly inside an `async def` with no executor/timeout wrapping, which would block the event loop if ever wired up. The live `get_or_create_note` tool is `tool_handlers.py::GetOrCreateNoteHandler`, which correctly wraps its blocking Simplenote API call in `loop.run_in_executor(...)` with `asyncio.wait_for(..., timeout=30.0)`. Do not route through `CacheManager.get_or_create_note` without adding the same guard.
+- **Offline mode** (`SIMPLENOTE_OFFLINE_MODE=true`): the mock client in `server.py::get_simplenote_client()` stubs `add_note`/`get_note`/`update_note` to return `({}, 0)` — an empty dict with no `'key'` field. Tests asserting on `note['key']` will fail against this mock.
+- **No hardcoded credentials** — environment variables and the keychain chain only.
+
+## Work Guidance
+
+- Follow existing error-hierarchy conventions (`errors.py`/`error_taxonomy.py`) for new failure modes rather than raising bare exceptions.
+- Google-style docstrings, full type hints, Ruff-formatted (88 char line length).
+
+## Verification
+
+- `make test-fast` (primary tree, exercises most of this package)
+- `mypy simplenote_mcp`
+- `bandit -c pyproject.toml -r simplenote_mcp`
+
+## Child DOX Index
+
+- `search/AGENTS.md` — query parser and boolean/fuzzy/date search engine
+- `monitoring/AGENTS.md` — metrics collection and alerting thresholds

--- a/simplenote_mcp/server/monitoring/AGENTS.md
+++ b/simplenote_mcp/server/monitoring/AGENTS.md
@@ -1,0 +1,27 @@
+# simplenote_mcp/server/monitoring/
+
+## Purpose
+
+Performance metrics collection (`metrics.py`) and alerting thresholds (`thresholds.py`) — API call rates, cache hit/miss, tool usage, system resources. See `README.md` in this folder for end-user dashboard/usage docs; this file covers agent-relevant contracts only.
+
+## Ownership
+
+- `metrics.py` — `MetricsCollector` (process-global singleton via `__new__`/`_instance`), `PerformanceMetrics`/`ApiMetrics`/`CacheMetrics`/`ResourceMetrics`/`ToolMetrics` containers, `record_*`/`get_metrics` functions.
+- `thresholds.py` — alert threshold definitions consumed by `server/alerting.py`.
+
+## Local Contracts
+
+- **`MetricsCollector` is a process-global singleton** — it cannot be reset by reassigning `_instance`; the only way to reset it between tests is replacing its `.metrics` attribute (see `_reset_process_global_singletons` in `simplenote_mcp/tests/conftest.py`). This is the root cause of why `tests/` and `simplenote_mcp/tests/` must run as separate pytest processes: each tree's autouse conftest fixture only resets state for its own tests, so collecting both trees into one pytest invocation lets one tree's leftover singleton state corrupt the other's assertions. Do not attempt to merge the two trees into one `testpaths` list without solving this isolation problem first.
+- Metrics persist to `simplenote_mcp/logs/metrics/performance_metrics.json`, path overridable via `METRICS_FILE_PATH`. Collection interval via `METRICS_COLLECTION_INTERVAL` (default 60s).
+
+## Work Guidance
+
+- New metric types: add to `metrics.py`, update `simplenote_mcp/scripts/monitoring_dashboard.py` if dashboard-visible, add tests, update `README.md`'s API reference table.
+
+## Verification
+
+- `make test-fast` (`tests/test_performance_monitoring.py` is 100% stable only when run in isolation from `simplenote_mcp/tests/` — see Local Contracts)
+
+## Child DOX Index
+
+None.

--- a/simplenote_mcp/server/monitoring/README.md
+++ b/simplenote_mcp/server/monitoring/README.md
@@ -2,6 +2,8 @@
 
 A comprehensive performance monitoring system for the Simplenote MCP Server that tracks API performance, cache efficiency, tool usage, and system resources.
 
+> Agent contracts (singleton/test-isolation gotchas) live in [`AGENTS.md`](AGENTS.md) in this folder — this file is end-user/dashboard usage documentation.
+
 ## Features
 
 - **API Performance Tracking**: Monitor API call success rates, response times, and error rates

--- a/simplenote_mcp/server/search/AGENTS.md
+++ b/simplenote_mcp/server/search/AGENTS.md
@@ -1,0 +1,30 @@
+# simplenote_mcp/server/search/
+
+## Purpose
+
+Advanced search: query tokenizing/parsing (`parser.py`), boolean expression evaluation (`engine.py`), fuzzy matching (`fuzzy.py`), and natural-language date resolution (`date_parser.py`). Used by `search_notes` and the cache's search indexing.
+
+## Ownership
+
+- `parser.py` — `QueryParser`/`QueryToken`: tokenizes `AND`/`OR`/`NOT`, quoted phrases, `tag:`/`from:`/`to:` filters, and parenthesized groups; inserts implicit `AND` between adjacent terms.
+- `engine.py` — `SearchEngine`: recursive-descent evaluator (`_parse_or_expression` → `_parse_and_expression` → `_parse_not_expression` → `_parse_primary`, standard OR/AND/NOT precedence) plus tag/date filtering and relevance scoring.
+- `fuzzy.py` — `FuzzyMatcher`, opt-in (`fuzzy: true`) `difflib.SequenceMatcher`-based approximate matching, default threshold 0.75.
+- `date_parser.py` — `parse_natural_date`: resolves expressions like `last_week`, `yesterday`, `3_days_ago` to ISO dates.
+
+## Local Contracts
+
+- Search matching is **substring-based, not tokenized** — a word-index pre-filter requires terms ≥3 characters to be indexed; shorter terms fall back to full-content scan.
+- Fuzzy matching only applies to terms ≥3 characters (`FuzzyMatcher`); shorter terms always use exact matching.
+- Boolean operator precedence is fixed by the recursive-descent structure: `OR` binds loosest, then `AND`, then `NOT`, then grouped/primary expressions — do not reorder `_parse_*_expression` call chains without updating this doc.
+
+## Work Guidance
+
+- New query syntax (new filter prefix, new operator) needs changes in both `parser.py` (tokenizing) and `engine.py` (evaluation) — they are not independently extensible.
+
+## Verification
+
+- `make test-fast` (`tests/test_advanced_search.py`, `tests/test_date_parser.py`, and related search test files)
+
+## Child DOX Index
+
+None.

--- a/simplenote_mcp/tests/AGENTS.md
+++ b/simplenote_mcp/tests/AGENTS.md
@@ -1,0 +1,31 @@
+# simplenote_mcp/tests/
+
+## Purpose
+
+Legacy pytest tree (15 test files) — restored to CI but deliberately kept as a **separate pytest invocation** from `tests/` (the primary, CI-wired tree; new tests always go there — see `tests/AGENTS.md`). Not listed in `pyproject.toml`'s `testpaths`.
+
+## Ownership
+
+- `test_*.py` — legacy coverage for compat shims, note operations/organization, error categorization, performance monitoring/thresholds, search, server capabilities, structured logging, tag filtering, MCP client behavior.
+- `conftest.py` — `_reset_process_global_singletons` (autouse) resets `MetricsCollector`/security-validator state for *this tree only* (see Local Contracts).
+- `benchmark_cache.py`, `monitor_server.py`, `pagination_and_cache_diagnostic.py` — manual/live-account scripts, not pytest tests (see Local Contracts).
+- `run_tests.py` — legacy category-based test runner predating the Makefile targets.
+- `unit/` — subdirectory, currently empty.
+
+## Local Contracts
+
+- **Never merge this tree into `tests/`'s `testpaths`.** Both trees mutate the same process-global singletons (`MetricsCollector` in `server/monitoring/metrics.py`, security-validator attempt-tracking) and each tree's autouse conftest fixture resets state only for its own tests. Collecting both into one pytest process lets one tree's leftover state corrupt the other's assertions — confirmed empirically against `test_performance_monitoring.py`.
+- **`pagination_and_cache_diagnostic.py` is not a pytest test module** despite living in this directory — its functions take a `cache: NoteCache` parameter with no matching fixture and require a real Simplenote account. It was previously named `test_pagination_and_cache.py`, which caused pytest to silently either error or vacuously "pass" (unawaited coroutine) without ever running. Do not rename it back to a `test_*` pattern.
+- Run with `SIMPLENOTE_OFFLINE_MODE=true`, `--no-cov` (excluded from the coverage gate that governs `tests/`).
+
+## Work Guidance
+
+- Treat this tree as maintenance-only — fix breakage here, but add new coverage to `tests/` instead.
+
+## Verification
+
+- `make test-legacy` — `SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest simplenote_mcp/tests/ -q --timeout=30 --no-cov`
+
+## Child DOX Index
+
+None.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,33 @@
+# tests/
+
+## Purpose
+
+Primary, CI-wired pytest tree (`testpaths = ["tests"]` in `pyproject.toml`) — 60 test files. All new tests go here, not in the legacy `simplenote_mcp/tests/` tree (see that folder's `AGENTS.md`).
+
+## Ownership
+
+- One `test_*.py` per source module/feature area (e.g. `test_cache.py`, `test_advanced_search.py`, `test_tool_handlers*.py`, `test_auth*.py`, `test_config.py`).
+- `conftest.py` — shared fixtures, all autouse unless noted: `isolate_token_file_cache` (redirects the keychain token-cache path to `tmp_path`), `reset_write_budget`, `reset_config_cache`, plus non-autouse `mock_simplenote_client`, `simplenote_env_vars`, `server_context`, `authenticated_context`.
+- `fixtures_rate_limit.py`, `fixtures_retry.py` — shared fixture modules for rate-limit/retry test scenarios.
+- `unit/` — currently empty; `test_server_comprehensive.py.disabled` / `test_server_integration.py.disabled` at this level are intentionally disabled, not stale cruft to delete without checking why first.
+
+## Local Contracts
+
+- Run with `SIMPLENOTE_OFFLINE_MODE=true` — real Simplenote credentials must never be required to run this suite.
+- Coverage gate: `--cov-fail-under=75` (`pyproject.toml` `addopts`).
+- Markers available: `unit`, `integration`, `perf`, `security`, `slow`, `network`, `auth`, `offline` (`--strict-markers` enforced — unregistered markers fail collection).
+- Do not merge this tree's pytest invocation with `simplenote_mcp/tests/` — both mutate process-global singletons (see `simplenote_mcp/server/monitoring/AGENTS.md`) and only reset state for their own tests.
+- Offline-mode mock client (`server.py::get_simplenote_client()`) returns `({}, 0)` from `add_note`/`get_note`/`update_note` — don't write assertions expecting a populated `note['key']` against the raw mock.
+
+## Work Guidance
+
+- New tool handler → add tests here, not in `simplenote_mcp/tests/`, per `simplenote_mcp/server/AGENTS.md`'s tool-handler pattern.
+- Prefer existing fixtures (`mock_simplenote_client`, `authenticated_context`) over hand-rolled mocks; grep for the symbol's real import path before mocking — mock where it's *used*, not where it's defined.
+
+## Verification
+
+- `make test-fast` — `SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest tests/ -x -q --timeout=30`
+
+## Child DOX Index
+
+None.


### PR DESCRIPTION
## Description

Handoff 2/3 of the DOX rollout (Bear note "Handoff 2/3: Install DOX AGENTS.md — simplenote-mcp-server"), following the same procedure as the mcp-wordpress pilot ([docdyhr/mcp-wordpress#204](https://github.com/docdyhr/mcp-wordpress/pull/204), merged) per the [DOX framework](https://github.com/agent0ai/dox) (MIT licensed).

- Root `AGENTS.md`: durable project content (commands, architecture, local contracts) sourced from the current codebase, followed by the DOX framework block installed as-is (headings nested under the project H1).
- Child `AGENTS.md` docs added for `simplenote_mcp/server/` (+ its `search/` and `monitoring/` subdirs), `simplenote_mcp/scripts/`, both test trees (`tests/` and `simplenote_mcp/tests/`), `scripts/`, `helm/`, and `.github/workflows/` — each sourced from the actual current code, not the (now-stale) recon in the original handoff plan.

## Notable corrections vs. the original handoff plan

- The handoff's two "known bugs" (async hang in `get_or_create_note`, boolean search parser bug) were **not reproducible against current `main`**: `get_or_create_note`'s live tool path (`tool_handlers.py::GetOrCreateNoteHandler`) already wraps its blocking Simplenote API call in `run_in_executor` + a 30s timeout, and the boolean search evaluator's OR/AND/NOT precedence looks structurally correct. Left both out of the tree rather than encode stale, unverified claims as active contracts.
- Found and documented a real issue instead: `cache_utils.py`'s `CacheManager.get_or_create_note` is dead/unused code with an *unguarded* blocking `sn.get_note()` call that would hang the event loop if it were ever wired up — flagged explicitly in `simplenote_mcp/server/AGENTS.md` so nobody routes through it without adding the same guard.
- `helm/AGENTS.md` flags that `values.yaml`'s `image.tag` isn't covered by the existing `check_version_consistency.py` script and can drift silently behind `Chart.yaml`'s `appVersion`.
- `.github/workflows/AGENTS.md` encodes two real past incidents as standing contracts: the `actionlint`-vs-`yaml.safe_load` SHA-pinning gotcha (a prior edit produced schema-invalid `uses:` lines that silently zeroed out CI on affected workflows) and the `github-script` `env:`-not-inline-`${{ }}` convention (script-injection prevention).
- `CLAUDE.md` turned out to already be gitignored in this repo (an explicit "Remove CLAUDE.md from version control" commit exists in history) — left untouched/uncommitted here rather than fighting that established convention.

## Type of Change
- [x] Documentation update

## Testing

- [x] `ruff check .` — clean
- [x] `mypy simplenote_mcp` — clean (70 source files)
- [x] `bandit -c pyproject.toml -r simplenote_mcp` — 2 pre-existing low-severity findings in `logging.py`, a file untouched by this PR; no new findings
- [x] `python scripts/quality/check_version_consistency.py` — all 5 version sources consistent
- [x] `make test-fast` — 1336 passed, 8 skipped
- [x] `make test-legacy` — 112 passed, 9 skipped
- [x] `markdownlint` (structural rules — this repo has no markdownlint CI/config, so line-length wasn't gated) — clean
- [x] Grepped all new/changed files for secrets/credentials — none found

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
