### PR TITLE
style: reformat markdown code fences with ruff 0.16.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,6 +53,7 @@ Generated code must pass these checks:
 from typing import Optional
 import logging
 
+
 def process_note(note_id: str, content: Optional[str] = None) -> bool:
     """Process a note with optional content update.
 

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -125,17 +125,25 @@ docker inspect --format='{{.State.Health.Status}}' simplenote-mcp-server
 import asyncio
 from mcp import StdioServerManager
 
+
 async def main():
-    async with StdioServerManager("docker", [
-        "run", "--rm", "-i",
-        "-e", "SIMPLENOTE_EMAIL=your-email@example.com",
-        "-e", "SIMPLENOTE_PASSWORD=your-password",
-        "docdyhr/simplenote-mcp-server:latest"
-    ]) as server:
+    async with StdioServerManager(
+        "docker",
+        [
+            "run",
+            "--rm",
+            "-i",
+            "-e",
+            "SIMPLENOTE_EMAIL=your-email@example.com",
+            "-e",
+            "SIMPLENOTE_PASSWORD=your-password",
+            "docdyhr/simplenote-mcp-server:latest",
+        ],
+    ) as server:
         # List available tools
         tools = await server.list_tools()
         print(f"Available tools: {[tool.name for tool in tools.tools]}")
-        
+
         # Search notes
         result = await server.call_tool("search_notes", {"query": "important"})
         print(f"Search results: {result}")

--- a/docs/api/cache.md
+++ b/docs/api/cache.md
@@ -40,12 +40,7 @@ The cache system can be configured using the following environment variables:
 ```python
 from simplenote_mcp.server.cache import NoteCache
 
-cache = NoteCache(
-    max_size=1000,
-    ttl=300,
-    strategy="lru",
-    persistent=False
-)
+cache = NoteCache(max_size=1000, ttl=300, strategy="lru", persistent=False)
 ```
 
 ## Cache Strategies
@@ -151,7 +146,7 @@ await cache.clear()
 notes_data = {
     "note1": {"content": "...", "tags": []},
     "note2": {"content": "...", "tags": ["work"]},
-    "note3": {"content": "...", "tags": ["personal"]}
+    "note3": {"content": "...", "tags": ["personal"]},
 }
 
 await cache.put_many(notes_data)
@@ -220,10 +215,12 @@ async def on_cache_hit(note_id: str):
     """Called when a cache hit occurs."""
     print(f"Cache hit for note: {note_id}")
 
-@cache.on_miss  
+
+@cache.on_miss
 async def on_cache_miss(note_id: str):
     """Called when a cache miss occurs."""
     print(f"Cache miss for note: {note_id}")
+
 
 @cache.on_eviction
 async def on_cache_eviction(note_id: str, reason: str):
@@ -275,7 +272,7 @@ print(f"Throughput: {metrics['requests_per_second']:.2f} req/s")
 ```python
 health = await cache.health_check()
 
-if health['status'] == 'healthy':
+if health["status"] == "healthy":
     print("Cache is operating normally")
 else:
     print(f"Cache issues detected: {health['issues']}")
@@ -288,9 +285,9 @@ else:
 ```python
 # Configure memory limits
 cache = NoteCache(
-    max_size=1000,              # Maximum number of items
-    max_memory_mb=100,          # Maximum memory usage in MB
-    max_item_size_kb=1024       # Maximum size per item in KB
+    max_size=1000,  # Maximum number of items
+    max_memory_mb=100,  # Maximum memory usage in MB
+    max_item_size_kb=1024,  # Maximum size per item in KB
 )
 ```
 
@@ -300,13 +297,13 @@ cache = NoteCache(
 # Enable compression for large notes
 cache = NoteCache(
     compression=True,
-    compression_threshold=1024  # Compress notes larger than 1KB
+    compression_threshold=1024,  # Compress notes larger than 1KB
 )
 
 # Configure garbage collection
 cache.configure_gc(
-    gc_interval=300,            # Run GC every 5 minutes
-    gc_threshold=0.8            # GC when 80% full
+    gc_interval=300,  # Run GC every 5 minutes
+    gc_threshold=0.8,  # GC when 80% full
 )
 ```
 
@@ -330,7 +327,7 @@ print(f"Memory utilization: {memory_info['utilization']:.1%}")
 cache = NoteCache(
     persistent=True,
     cache_dir="~/.simplenote-cache",
-    persistence_format="json"  # or "pickle", "msgpack"
+    persistence_format="json",  # or "pickle", "msgpack"
 )
 ```
 
@@ -339,10 +336,10 @@ cache = NoteCache(
 ```python
 # Configure persistence behavior
 cache.configure_persistence(
-    save_interval=60,           # Save to disk every minute
-    load_on_startup=True,       # Load cache on startup
-    compress_files=True,        # Compress cache files
-    max_file_age_days=7         # Delete files older than 7 days
+    save_interval=60,  # Save to disk every minute
+    load_on_startup=True,  # Load cache on startup
+    compress_files=True,  # Compress cache files
+    max_file_age_days=7,  # Delete files older than 7 days
 )
 ```
 
@@ -368,7 +365,7 @@ from simplenote_mcp.cache.exceptions import (
     CacheError,
     CacheFullError,
     CacheCorruptionError,
-    PersistenceError
+    PersistenceError,
 )
 
 try:
@@ -390,10 +387,10 @@ except PersistenceError as e:
 ```python
 # Configure error recovery
 cache.configure_error_handling(
-    auto_recovery=True,         # Automatically recover from errors
-    max_retries=3,              # Maximum retry attempts
-    retry_delay=1.0,            # Delay between retries
-    fallback_to_memory=True     # Fall back to memory-only on persistence errors
+    auto_recovery=True,  # Automatically recover from errors
+    max_retries=3,  # Maximum retry attempts
+    retry_delay=1.0,  # Delay between retries
+    fallback_to_memory=True,  # Fall back to memory-only on persistence errors
 )
 ```
 
@@ -418,11 +415,11 @@ async def warm_cache():
     """Pre-populate cache with frequently accessed notes."""
     # Get most recently accessed notes
     recent_notes = await get_recent_notes(limit=100)
-    
+
     # Pre-load into cache
     for note in recent_notes:
-        await cache.put(note['id'], note)
-    
+        await cache.put(note["id"], note)
+
     print(f"Warmed cache with {len(recent_notes)} notes")
 ```
 
@@ -432,11 +429,11 @@ async def warm_cache():
 async def monitor_cache():
     """Monitor cache performance and adjust if needed."""
     stats = await cache.get_stats()
-    
-    if stats['hit_ratio'] < 0.7:  # Less than 70% hit ratio
+
+    if stats["hit_ratio"] < 0.7:  # Less than 70% hit ratio
         print("Cache hit ratio is low, consider increasing cache size")
-    
-    if stats['memory_usage_mb'] > 90:  # Using more than 90% of allocated memory
+
+    if stats["memory_usage_mb"] > 90:  # Using more than 90% of allocated memory
         print("Cache memory usage is high, consider cleanup")
         await cache.cleanup_expired()
 ```
@@ -450,11 +447,11 @@ class PartitionedCache:
         self.work_cache = NoteCache(max_size=500, ttl=600)
         self.personal_cache = NoteCache(max_size=300, ttl=1800)
         self.archive_cache = NoteCache(max_size=200, ttl=3600)
-    
+
     async def get_cache(self, note_tags):
-        if 'work' in note_tags:
+        if "work" in note_tags:
             return self.work_cache
-        elif 'personal' in note_tags:
+        elif "personal" in note_tags:
             return self.personal_cache
         else:
             return self.archive_cache
@@ -467,21 +464,22 @@ class PartitionedCache:
 ```python
 from simplenote_mcp.cache.testing import CacheTestUtils
 
+
 async def test_cache_behavior():
     # Create test cache
     cache = CacheTestUtils.create_test_cache()
-    
+
     # Populate with test data
     await CacheTestUtils.populate_cache(cache, num_notes=100)
-    
+
     # Verify cache behavior
     assert await cache.get("test_note_1") is not None
-    assert cache.get_stats()['current_size'] == 100
-    
+    assert cache.get_stats()["current_size"] == 100
+
     # Test eviction
     await CacheTestUtils.fill_cache_to_capacity(cache)
     stats = cache.get_stats()
-    assert stats['evictions'] > 0
+    assert stats["evictions"] > 0
 ```
 
 ### Performance Testing
@@ -490,21 +488,21 @@ async def test_cache_behavior():
 async def benchmark_cache():
     """Benchmark cache performance."""
     cache = NoteCache(max_size=1000)
-    
+
     # Benchmark write performance
     start_time = time.time()
     for i in range(1000):
         await cache.put(f"note_{i}", {"content": f"Content {i}"})
     write_time = time.time() - start_time
-    
-    # Benchmark read performance  
+
+    # Benchmark read performance
     start_time = time.time()
     for i in range(1000):
         await cache.get(f"note_{i}")
     read_time = time.time() - start_time
-    
-    print(f"Write performance: {1000/write_time:.2f} ops/sec")
-    print(f"Read performance: {1000/read_time:.2f} ops/sec")
+
+    print(f"Write performance: {1000 / write_time:.2f} ops/sec")
+    print(f"Read performance: {1000 / read_time:.2f} ops/sec")
 ```
 
 ## Integration with MCP Server
@@ -541,7 +539,7 @@ cache = NoteCache(debug=True, log_level="DEBUG")
 
 # This will log all cache operations
 await cache.put(note_id, note_data)  # Logs: "Cache PUT: note_123"
-await cache.get(note_id)             # Logs: "Cache HIT: note_123"
+await cache.get(note_id)  # Logs: "Cache HIT: note_123"
 ```
 
 ### Cache Validation
@@ -550,7 +548,7 @@ await cache.get(note_id)             # Logs: "Cache HIT: note_123"
 # Validate cache integrity
 validation_result = await cache.validate()
 
-if not validation_result['valid']:
+if not validation_result["valid"]:
     print(f"Cache validation failed: {validation_result['errors']}")
     await cache.rebuild_cache()
 ```

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -113,14 +113,14 @@ results = await search_engine.search("project AND status", tags=["work"])
 from simplenote_mcp.server.search import AdvancedSearchEngine
 
 search_engine = AdvancedSearchEngine(
-    case_sensitive=False,           # Case-insensitive search by default
-    stemming=True,                  # Enable word stemming
-    stop_words=True,               # Filter common stop words
-    max_results=100,               # Maximum results per search
-    search_timeout=30,             # Search timeout in seconds
-    cache_results=True,            # Cache search results
-    fuzzy_matching=False,          # Disable fuzzy matching by default
-    min_score=0.1                  # Minimum relevance score
+    case_sensitive=False,  # Case-insensitive search by default
+    stemming=True,  # Enable word stemming
+    stop_words=True,  # Filter common stop words
+    max_results=100,  # Maximum results per search
+    search_timeout=30,  # Search timeout in seconds
+    cache_results=True,  # Cache search results
+    fuzzy_matching=False,  # Disable fuzzy matching by default
+    min_score=0.1,  # Minimum relevance score
 )
 ```
 
@@ -146,10 +146,7 @@ results = await search_engine.search("python programming")
 
 # Search with options
 results = await search_engine.search(
-    query="machine learning",
-    limit=50,
-    include_deleted=False,
-    sort_by="relevance"
+    query="machine learning", limit=50, include_deleted=False, sort_by="relevance"
 )
 ```
 
@@ -165,7 +162,7 @@ results = await search_engine.advanced_search(
     min_length=100,
     max_length=5000,
     sort_by="modified_date",
-    sort_order="desc"
+    sort_order="desc",
 )
 ```
 
@@ -175,7 +172,7 @@ results = await search_engine.advanced_search(
 # Search by tags only
 results = await search_engine.search_by_tags(
     tags=["work", "meeting"],
-    operator="AND"  # or "OR"
+    operator="AND",  # or "OR"
 )
 
 # Get all available tags
@@ -190,16 +187,11 @@ notes = await search_engine.get_notes_by_tag("work", limit=20)
 ```python
 # Search in note content only
 results = await search_engine.search_content(
-    query="algorithm implementation",
-    case_sensitive=False,
-    whole_words=True
+    query="algorithm implementation", case_sensitive=False, whole_words=True
 )
 
 # Search in note titles only
-results = await search_engine.search_titles(
-    query="weekly report",
-    fuzzy=True
-)
+results = await search_engine.search_titles(query="weekly report", fuzzy=True)
 ```
 
 ## Search Result Format
@@ -220,9 +212,9 @@ results = await search_engine.search_titles(
             "highlights": [
                 {
                     "field": "content",
-                    "fragment": "...comprehensive guide to <mark>Python</mark> <mark>programming</mark>..."
+                    "fragment": "...comprehensive guide to <mark>Python</mark> <mark>programming</mark>...",
                 }
-            ]
+            ],
         }
     ],
     "total_results": 15,
@@ -230,8 +222,8 @@ results = await search_engine.search_titles(
     "query_info": {
         "original_query": "python programming",
         "parsed_query": "python AND programming",
-        "filters_applied": ["active_notes_only"]
-    }
+        "filters_applied": ["active_notes_only"],
+    },
 }
 ```
 
@@ -252,11 +244,11 @@ Search results include highlighted snippets showing where matches were found:
 ```python
 # Highlighting configuration
 search_engine.configure_highlighting(
-    highlight_tag="<mark>",          # HTML tag for highlights
-    close_tag="</mark>",            # Closing tag
-    fragment_size=150,              # Characters per fragment
-    max_fragments=3,                # Maximum fragments per note
-    fragment_separator="..."        # Separator between fragments
+    highlight_tag="<mark>",  # HTML tag for highlights
+    close_tag="</mark>",  # Closing tag
+    fragment_size=150,  # Characters per fragment
+    max_fragments=3,  # Maximum fragments per note
+    fragment_separator="...",  # Separator between fragments
 )
 ```
 
@@ -282,10 +274,10 @@ print(f"Last updated: {index_info['last_updated']}")
 ```python
 # Configure search performance
 search_engine.configure_performance(
-    index_update_interval=300,      # Update index every 5 minutes
-    background_indexing=True,       # Index updates in background
-    parallel_search=True,           # Enable parallel search
-    max_concurrent_searches=5       # Limit concurrent searches
+    index_update_interval=300,  # Update index every 5 minutes
+    background_indexing=True,  # Index updates in background
+    parallel_search=True,  # Enable parallel search
+    max_concurrent_searches=5,  # Limit concurrent searches
 )
 ```
 
@@ -296,9 +288,9 @@ Search results are automatically cached for improved performance:
 ```python
 # Configure search caching
 search_engine.configure_cache(
-    cache_size=1000,               # Cache up to 1000 search results
-    cache_ttl=300,                 # Cache for 5 minutes
-    cache_similar_queries=True     # Cache similar queries
+    cache_size=1000,  # Cache up to 1000 search results
+    cache_ttl=300,  # Cache for 5 minutes
+    cache_similar_queries=True,  # Cache similar queries
 )
 
 # Clear search cache
@@ -324,8 +316,7 @@ print(f"Most common queries: {stats['top_queries']}")
 ```python
 # Analyze query patterns
 analysis = await search_engine.analyze_queries(
-    start_date="2024-01-01",
-    end_date="2024-12-31"
+    start_date="2024-01-01", end_date="2024-12-31"
 )
 
 print(f"Most searched terms: {analysis['top_terms']}")
@@ -342,7 +333,7 @@ from simplenote_mcp.server.errors import (
     SearchError,
     QueryParseError,
     SearchTimeoutError,
-    IndexError
+    IndexError,
 )
 
 try:
@@ -363,10 +354,10 @@ except SearchError as e:
 ```python
 # Configure error handling
 search_engine.configure_error_handling(
-    auto_retry=True,               # Automatically retry failed searches
-    max_retries=3,                 # Maximum retry attempts
-    retry_delay=1.0,               # Delay between retries
-    fallback_to_simple=True        # Fall back to simple search on complex query failure
+    auto_retry=True,  # Automatically retry failed searches
+    max_retries=3,  # Maximum retry attempts
+    retry_delay=1.0,  # Delay between retries
+    fallback_to_simple=True,  # Fall back to simple search on complex query failure
 )
 ```
 
@@ -379,13 +370,15 @@ Enable fuzzy matching for typo tolerance:
 ```python
 # Enable fuzzy search
 search_engine.enable_fuzzy_search(
-    threshold=0.8,                 # Similarity threshold (0.0-1.0)
-    max_distance=2,                # Maximum edit distance
-    prefix_length=1                # Minimum prefix match length
+    threshold=0.8,  # Similarity threshold (0.0-1.0)
+    max_distance=2,  # Maximum edit distance
+    prefix_length=1,  # Minimum prefix match length
 )
 
 # Fuzzy search example
-results = await search_engine.fuzzy_search("pythno programing")  # Finds "python programming"
+results = await search_engine.fuzzy_search(
+    "pythno programing"
+)  # Finds "python programming"
 ```
 
 ### Semantic Search
@@ -395,8 +388,7 @@ Enable semantic search for concept-based matching:
 ```python
 # Enable semantic search (requires additional setup)
 search_engine.enable_semantic_search(
-    model="sentence-transformers/all-MiniLM-L6-v2",
-    similarity_threshold=0.7
+    model="sentence-transformers/all-MiniLM-L6-v2", similarity_threshold=0.7
 )
 
 # Semantic search example
@@ -412,21 +404,22 @@ Define custom scoring functions for search results:
 def custom_scorer(note, query_terms):
     """Custom scoring function."""
     score = 0.0
-    
+
     # Boost recent notes
-    days_old = (datetime.now() - note['modified_date']).days
+    days_old = (datetime.now() - note["modified_date"]).days
     recency_boost = max(0, 1.0 - days_old / 365)
     score += recency_boost * 0.2
-    
+
     # Boost notes with many tags
-    tag_boost = min(len(note['tags']) * 0.1, 0.3)
+    tag_boost = min(len(note["tags"]) * 0.1, 0.3)
     score += tag_boost
-    
+
     # Boost shorter notes (easier to read)
-    length_penalty = min(len(note['content']) / 10000, 0.2)
+    length_penalty = min(len(note["content"]) / 10000, 0.2)
     score -= length_penalty
-    
+
     return score
+
 
 # Register custom scorer
 search_engine.register_scorer("custom", custom_scorer)
@@ -445,18 +438,17 @@ Define reusable search filters:
 def recent_notes_filter(note):
     """Filter for notes modified in the last 30 days."""
     cutoff = datetime.now() - timedelta(days=30)
-    return note['modified_date'] > cutoff
+    return note["modified_date"] > cutoff
+
 
 @search_engine.filter("long")
 def long_notes_filter(note):
     """Filter for notes longer than 1000 characters."""
-    return len(note['content']) > 1000
+    return len(note["content"]) > 1000
+
 
 # Use filters in search
-results = await search_engine.search(
-    "machine learning",
-    filters=["recent", "long"]
-)
+results = await search_engine.search("machine learning", filters=["recent", "long"])
 ```
 
 ## Integration Examples
@@ -466,23 +458,20 @@ results = await search_engine.search(
 ```python
 from simplenote_mcp.server import SimplenoteServer
 
+
 class SimplenoteServer:
     def __init__(self):
         self.search_engine = AdvancedSearchEngine()
-    
+
     @tool("search_notes")
     async def search_notes(self, query: str, tags: list = None, limit: int = 20):
         """Search notes with advanced features."""
-        results = await self.search_engine.search(
-            query=query,
-            tags=tags,
-            limit=limit
-        )
-        
+        results = await self.search_engine.search(query=query, tags=tags, limit=limit)
+
         return {
             "results": results["results"],
             "total": results["total_results"],
-            "search_time": results["search_time_ms"]
+            "search_time": results["search_time_ms"],
         }
 ```
 
@@ -545,23 +534,23 @@ print(f"Test pass rate: {test_results['pass_rate']:.2%}")
 async def benchmark_search():
     """Benchmark search performance."""
     search_engine = AdvancedSearchEngine()
-    
+
     # Test different query types
     queries = [
         "simple search",
         "boolean AND search",
         '"exact phrase"',
         "wildcard search*",
-        "complex (query OR search) AND test"
+        "complex (query OR search) AND test",
     ]
-    
+
     for query in queries:
         start_time = time.time()
         results = await search_engine.search(query)
         search_time = time.time() - start_time
-        
+
         print(f"Query: {query}")
-        print(f"Time: {search_time*1000:.2f} ms")
+        print(f"Time: {search_time * 1000:.2f} ms")
         print(f"Results: {len(results['results'])}")
         print("---")
 ```
@@ -613,7 +602,7 @@ results = await search_engine.search("debug query")
 ```python
 # Check index health
 health = await search_engine.check_index_health()
-if not health['healthy']:
+if not health["healthy"]:
     print(f"Index issues: {health['issues']}")
     await search_engine.rebuild_index()
 

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -282,11 +282,7 @@ The server implements comprehensive error handling:
 Raised when Simplenote credentials are invalid or expired.
 
 ```python
-{
-  "error": "AuthenticationError",
-  "message": "Invalid email or password",
-  "code": 401
-}
+{"error": "AuthenticationError", "message": "Invalid email or password", "code": 401}
 ```
 
 #### NoteNotFoundError
@@ -294,9 +290,9 @@ Raised when a requested note doesn't exist.
 
 ```python
 {
-  "error": "NoteNotFoundError", 
-  "message": "Note with ID 'abc123' not found",
-  "code": 404
+    "error": "NoteNotFoundError",
+    "message": "Note with ID 'abc123' not found",
+    "code": 404,
 }
 ```
 
@@ -305,9 +301,9 @@ Raised when Simplenote API rate limits are exceeded.
 
 ```python
 {
-  "error": "RateLimitError",
-  "message": "Rate limit exceeded, please try again later",
-  "code": 429
+    "error": "RateLimitError",
+    "message": "Rate limit exceeded, please try again later",
+    "code": 429,
 }
 ```
 
@@ -315,11 +311,7 @@ Raised when Simplenote API rate limits are exceeded.
 Raised when network connectivity issues occur.
 
 ```python
-{
-  "error": "NetworkError",
-  "message": "Failed to connect to Simplenote API",
-  "code": 503
-}
+{"error": "NetworkError", "message": "Failed to connect to Simplenote API", "code": 503}
 ```
 
 ## Caching System
@@ -330,9 +322,9 @@ The server implements intelligent caching for improved performance:
 
 ```python
 cache_config = {
-    "size": 1000,        # Maximum cached notes
-    "ttl": 300,          # Time-to-live in seconds
-    "strategy": "lru"    # Least Recently Used eviction
+    "size": 1000,  # Maximum cached notes
+    "ttl": 300,  # Time-to-live in seconds
+    "strategy": "lru",  # Least Recently Used eviction
 }
 ```
 
@@ -365,9 +357,9 @@ The server respects Simplenote's rate limits:
 ```python
 # Configure memory usage
 memory_config = {
-    "cache_size": 1000,     # Notes in memory
+    "cache_size": 1000,  # Notes in memory
     "max_content_size": 1024 * 1024,  # 1MB per note
-    "cleanup_interval": 300  # Cleanup every 5 minutes
+    "cleanup_interval": 300,  # Cleanup every 5 minutes
 }
 ```
 
@@ -402,6 +394,7 @@ from simplenote_mcp.server import SimplenoteServer
 
 server = SimplenoteServer()
 
+
 @server.tool("custom_tool")
 async def custom_tool(args: dict) -> dict:
     """Custom tool implementation."""
@@ -416,7 +409,8 @@ async def on_note_created(note_id: str, note_data: dict):
     """Called when a note is created."""
     pass
 
-@server.on_note_updated  
+
+@server.on_note_updated
 async def on_note_updated(note_id: str, note_data: dict):
     """Called when a note is updated."""
     pass
@@ -428,11 +422,7 @@ async def on_note_updated(note_id: str, note_data: dict):
 @server.resource_provider("custom://")
 async def custom_resource_provider(uri: str) -> dict:
     """Custom resource provider."""
-    return {
-        "uri": uri,
-        "name": "Custom Resource",
-        "content": "Custom content"
-    }
+    return {"uri": uri, "name": "Custom Resource", "content": "Custom content"}
 ```
 
 ## API Reference Links

--- a/docs/ci-cd-resolution-summary.md
+++ b/docs/ci-cd-resolution-summary.md
@@ -178,9 +178,9 @@ concurrency:
 ### Offline Mode Configuration
 ```python
 # simplenote_mcp/server/config.py
-self.offline_mode: bool = os.environ.get("SIMPLENOTE_OFFLINE_MODE", "false").lower() in (
-    "true", "1", "t", "yes"
-)
+self.offline_mode: bool = os.environ.get(
+    "SIMPLENOTE_OFFLINE_MODE", "false"
+).lower() in ("true", "1", "t", "yes")
 
 # Skip credential validation in offline mode
 if not self.offline_mode and not self.has_credentials:

--- a/docs/development/formatting-checklist.md
+++ b/docs/development/formatting-checklist.md
@@ -67,6 +67,7 @@ pytest tests/ -k "not integration"
 ```python
 # ❌ Wrong: Imports not at top
 import sys
+
 print("Hello")
 import os
 
@@ -83,6 +84,7 @@ print("Hello")
 # ❌ Wrong: No type hints
 def process_note(note_id, content=None):
     return True
+
 
 # ✅ Correct: Proper type hints
 def process_note(note_id: str, content: Optional[str] = None) -> bool:

--- a/docs/operations/error-categorization.md
+++ b/docs/operations/error-categorization.md
@@ -83,9 +83,9 @@ from simplenote_mcp.server.errors import ValidationError
 raise ValidationError("Note content cannot be empty", field="content")
 
 # With subcategory
-raise ValidationError("Note content cannot be empty", 
-                    subcategory="required", 
-                    field="content")
+raise ValidationError(
+    "Note content cannot be empty", subcategory="required", field="content"
+)
 
 # With detailed context
 raise ValidationError(
@@ -94,7 +94,7 @@ raise ValidationError(
     field="content",
     operation="create_note",
     resource_id="note123",
-    details={"max_length": 200000}
+    details={"max_length": 200000},
 )
 ```
 
@@ -110,7 +110,9 @@ try:
     result = api_call()
 except Exception as e:
     # Convert to appropriate ServerError type
-    error = handle_exception(e, context="calling Simplenote API", operation="sync_notes")
+    error = handle_exception(
+        e, context="calling Simplenote API", operation="sync_notes"
+    )
     # Use the structured error information
     print(f"Error code: {error.error_code}")
     print(f"User message: {error.get_user_message()}")

--- a/docs/operations/structured-logging.md
+++ b/docs/operations/structured-logging.md
@@ -37,10 +37,14 @@ To add context to your logs, use the `with_context()` method or the `extra` para
 
 ```python
 # Using with_context method (recommended)
-logger.with_context(note_id="abc123", operation="update").info("Note updated successfully")
+logger.with_context(note_id="abc123", operation="update").info(
+    "Note updated successfully"
+)
 
 # Using extra parameter (compatible with standard logging)
-logger.info("Note updated successfully", extra={"note_id": "abc123", "operation": "update"})
+logger.info(
+    "Note updated successfully", extra={"note_id": "abc123", "operation": "update"}
+)
 ```
 
 ### 3. Component-Specific Loggers
@@ -90,21 +94,24 @@ from simplenote_mcp.server import get_logger
 
 perf_logger = get_logger("performance")
 
+
 def measure_execution_time(func):
     def wrapper(*args, **kwargs):
         start_time = time.time()
         result = func(*args, **kwargs)
         duration_ms = (time.time() - start_time) * 1000
-        
+
         perf_logger.with_context(
             function=func.__name__,
             duration_ms=duration_ms,
             args_count=len(args),
-            kwargs_count=len(kwargs)
+            kwargs_count=len(kwargs),
         ).info(f"Function {func.__name__} execution completed")
-        
+
         return result
+
     return wrapper
+
 
 @measure_execution_time
 def my_function(arg1, arg2):
@@ -173,14 +180,11 @@ logger.error(f"Failed to find note with ID {note_id}")
 #### After
 
 ```python
-logger.with_context(
-    notes_count=notes_count,
-    duration_seconds=elapsed
-).info("Updated notes in cache")
+logger.with_context(notes_count=notes_count, duration_seconds=elapsed).info(
+    "Updated notes in cache"
+)
 
-logger.with_context(
-    note_id=note_id
-).error("Failed to find note")
+logger.with_context(note_id=note_id).error("Failed to find note")
 ```
 
 ### Best Practices
@@ -218,18 +222,15 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.Content]:
     # Create a request-specific logger
     request_id = str(uuid.uuid4())
     req_logger = get_request_logger(
-        request_id,
-        tool_name=name,
-        arguments=json.dumps(arguments)
+        request_id, tool_name=name, arguments=json.dumps(arguments)
     )
-    
+
     req_logger.info("Tool call received")
-    
+
     # Later in the function
-    req_logger.with_context(
-        result_type="success",
-        note_id=result_id
-    ).info("Tool call completed")
+    req_logger.with_context(result_type="success", note_id=result_id).info(
+        "Tool call completed"
+    )
 ```
 
 ### Cache Operations
@@ -239,18 +240,15 @@ async def sync(self) -> int:
     """Synchronize the cache with Simplenote."""
     sync_id = str(uuid.uuid4())
     sync_logger = get_request_logger(
-        sync_id,
-        operation="cache_sync",
-        last_sync=self._last_sync
+        sync_id, operation="cache_sync", last_sync=self._last_sync
     )
-    
+
     sync_logger.debug("Starting cache sync")
-    
+
     # Later in the function
-    sync_logger.with_context(
-        changes_count=change_count,
-        duration_seconds=elapsed
-    ).info("Cache sync completed")
+    sync_logger.with_context(changes_count=change_count, duration_seconds=elapsed).info(
+        "Cache sync completed"
+    )
 ```
 
 ## Reference

--- a/docs/testing/CACHE_COVERAGE_PLAN.md
+++ b/docs/testing/CACHE_COVERAGE_PLAN.md
@@ -158,19 +158,19 @@ def test_cache_at_max_capacity():
 async def test_background_sync_network_timeout():
     """Test background sync handling of network timeouts."""
     cache = NoteCache(sync_interval=1)
-    
-    with patch('simplenote.Simplenote.get_note_list') as mock_sync:
+
+    with patch("simplenote.Simplenote.get_note_list") as mock_sync:
         mock_sync.side_effect = TimeoutError("Network timeout")
-        
+
         sync_manager = BackgroundSync(cache, sync_interval=0.1)
         sync_manager.start()
-        
+
         await asyncio.sleep(0.2)
-        
+
         # Verify cache remains operational
         cache.set("key", "value")
         assert cache.get("key") == "value"
-        
+
         # Verify error was logged
         assert "Network timeout" in captured_logs
 ```
@@ -181,17 +181,17 @@ async def test_background_sync_network_timeout():
 async def test_background_sync_invalid_data():
     """Test background sync handling of corrupted data."""
     cache = NoteCache()
-    
-    with patch('simplenote.Simplenote.get_note_list') as mock_sync:
+
+    with patch("simplenote.Simplenote.get_note_list") as mock_sync:
         # Return malformed data
         mock_sync.return_value = [None, {"invalid": "structure"}]
-        
+
         sync_manager = BackgroundSync(cache, sync_interval=0.1)
         result = await sync_manager.sync_once()
-        
+
         # Should handle gracefully
         assert result is False or result is None
-        
+
         # Cache should still be usable
         cache.set("key", "value")
         assert cache.get("key") == "value"
@@ -480,14 +480,15 @@ pytest tests/test_cache*.py -k "edge_case or boundary"
 import coverage
 import json
 
+
 def analyze_missing_coverage():
     """Analyze which cache.py lines are not covered."""
     cov = coverage.Coverage()
     cov.load()
-    
-    analysis = cov.analysis('simplenote_mcp/server/cache.py')
+
+    analysis = cov.analysis("simplenote_mcp/server/cache.py")
     missing_lines = analysis[2]  # Lines not covered
-    
+
     print(f"Missing coverage on {len(missing_lines)} lines:")
     for line in missing_lines:
         print(f"  Line {line}")

--- a/simplenote_mcp/docs/monitoring_integration.md
+++ b/simplenote_mcp/docs/monitoring_integration.md
@@ -22,7 +22,7 @@ The `MetricsCollector` class provides a singleton instance that collects metrics
 from simplenote_mcp.server.monitoring.metrics import (
     start_metrics_collection,
     record_api_call,
-    record_response_time, 
+    record_response_time,
     record_cache_hit,
     record_cache_miss,
     record_tool_call,
@@ -137,7 +137,9 @@ def get_simplenote_client():
         record_response_time("get_simplenote_client", time.time() - api_start_time)
         return client
     except Exception as e:
-        record_api_call("get_simplenote_client", success=False, error_type=type(e).__name__)
+        record_api_call(
+            "get_simplenote_client", success=False, error_type=type(e).__name__
+        )
         raise
 ```
 

--- a/simplenote_mcp/server/monitoring/README.md
+++ b/simplenote_mcp/server/monitoring/README.md
@@ -44,7 +44,7 @@ from simplenote_mcp.server.monitoring.metrics import (
     record_api_call,
     record_response_time,
     record_cache_hit,
-    record_cache_miss
+    record_cache_miss,
 )
 ```
 


### PR DESCRIPTION
## Description
Fixes the `Validate` / `ruff format --check .` CI failure that's been on `main` since before PR #745 (root-caused: `ruff` 0.16.0, pinned in `pyproject.toml` via a recent Dependabot bump, started formatting Python code fences embedded in Markdown files — a new behavior vs. the previously-pinned 0.15.x). Ran `ruff format .` to bring the 12 affected docs into line with the new formatter output. Purely cosmetic (trailing commas, blank lines) — no code-sample logic or content changed; verified each diff by hand.

## Related Issue
Follow-up from the 2026-07-26 audit handoff / PR #745 merge, where CI's pre-existing `Validate`/`Local Test`/`CI Status` failures were confirmed to predate that PR (same failure on `main` at `de527372`, hours before #745 was opened).

## Type of Change
- [x] Documentation update

## Testing
- [x] `.venv/bin/ruff check .` — all checks passed
- [x] `.venv/bin/ruff format --check .` — 256 files already formatted (was 244 formatted / 12 needing reformat)
- [x] `.venv/bin/mypy simplenote_mcp` — no issues in 69 source files
- [x] `SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest tests/ -x -q --timeout=30` — 1336 passed, 8 skipped, 81.92% coverage

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Summary by Sourcery

Documentation:
- Updated API, server, cache, operations, testing, Docker usage, monitoring, and development documentation to match ruff 0.16.0 formatting for embedded code fences, including argument layouts, trailing commas, string quoting, and spacing.