### PR TITLE
fix: pin mcp[cli]<2.0.0 to unblock CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 27 registered tools → 30 (9 read + 21 write).
 
 ### Fixed
+- **CI broken by an unpinned `mcp` major release**: `mcp[cli]>=1.10.0` had no upper bound, so a
+  fresh `mcp` 2.0.0 release (which removes/renames the `Server.list_resources` decorator API this
+  server registers `handle_list_resources` with) was picked up by CI's `Test`/`Local Test` jobs —
+  both install from `pyproject.toml` directly rather than the pinned `requirements-lock.txt`
+  (`mcp==1.28.1`) — breaking pytest collection entirely (38 errors) and failing the required
+  `CI Status` check on `main`. Pinned to `mcp[cli]>=1.10.0,<2.0.0` as an immediate fix; migrating
+  to the 2.0.0 API is tracked separately.
 - **Every `npm run eval:*` suite was broken by a wrong Python interpreter**: `mcp-server-wrapper.ts`
   spawned the MCP server via bare `spawn("python3", ...)`, which resolves to whatever's first on
   PATH — Homebrew's or pyenv's global Python — not this project's `.venv`. Since the `mcp` package

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -168,6 +168,7 @@ A full repository review (security, runtime correctness, deployment, dependencie
 | **Multi-account support** | Needs config and auth refactor. |
 | **Real-time sync** | Replaces polling model. Requires Simperium websocket integration. |
 | **Multi-device Vault key sync** | Deferred from Phase 9 — needs an out-of-band key transfer story. |
+| **Migrate to `mcp` Python SDK v2** | v2.0.0 (2026-07-28) replaces the low-level `Server`'s decorator API (`@server.list_resources()`, `.read_resource()`, `.list_tools()`, `.call_tool()`, `.list_prompts()`, `.get_prompt()` — 6 total, `server.py:689,821,918,1745,1864,1934`) with constructor `on_*` params, which means `server = Server(...)` (currently `server.py:177`, before any handlers are defined) must move to after all 6 handler functions exist — a real restructure, not a find-replace. Pinned to `mcp[cli]<2.0.0` for now (see CHANGELOG); v1.x is in SDK maintainer-confirmed maintenance mode (security fixes only), so this isn't urgent, but shouldn't sit unpinned indefinitely. |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.17.5"
 description = "A simple MCP Server that connects to Simplenote"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = [ "mcp[cli]>=1.10.0", "simplenote>=2.1.4", "requests>=2.33.0", "starlette>=0.49.1", "uvicorn>=0.44.0", "urllib3>=2.6.3", "aiohttp>=3.9.0", "python-dateutil>=2.8.0", "cryptography>=44.0.0", "keyring>=24.0.0",]
+dependencies = [ "mcp[cli]>=1.10.0,<2.0.0", "simplenote>=2.1.4", "requests>=2.33.0", "starlette>=0.49.1", "uvicorn>=0.44.0", "urllib3>=2.6.3", "aiohttp>=3.9.0", "python-dateutil>=2.8.0", "cryptography>=44.0.0", "keyring>=24.0.0",]
 [[project.authors]]
 name = "Thomas Juul Dyhr"
 email = "docdyhr@me.com"


### PR DESCRIPTION
## Summary
- `mcp[cli]>=1.10.0` had no upper bound. CI's `Test`/`Local Test` jobs install from `pyproject.toml` directly (not the pinned `requirements-lock.txt`, which already has `mcp==1.28.1`), so the freshly-published `mcp` 2.0.0 was picked up and broke pytest collection across the whole suite (38 errors) — `mcp` 2.0.0 removes/renames the `Server.list_resources` decorator API this server registers `handle_list_resources` with.
- Pins to `mcp[cli]>=1.10.0,<2.0.0` as an immediate unblock. Migration to the 2.0.0 API is tracked separately in ROADMAP.md.

## Root cause (confirmed via CI logs, run [30431248393](https://github.com/docdyhr/simplenote-mcp-server/actions/runs/30431248393))
```
Collecting mcp>=1.10.0 (from mcp[cli]>=1.10.0->simplenote-mcp-server==1.17.5)
  Downloading mcp-2.0.0-py3-none-any.whl.metadata
...
AttributeError: 'Server' object has no attribute 'list_resources'
ImportError: cannot import name 'server' from 'simplenote_mcp'
```
Last green run on `main` was `838759f` (2026-07-28T08:24Z); every run since has failed the same way.

## Test plan
- [x] CI (`Unified CI/CD Pipeline`) passes on this branch
- [x] `make test-fast` passes locally
- [ ] Confirm `check_version_consistency.py` / Validate job still green (no version bump here, so should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin the Python MCP CLI dependency below version 2.0.0 to restore compatibility with the existing server code and unblock failing CI, and document both the regression and the planned migration to MCP SDK v2.

Bug Fixes:
- Prevent CI test failures caused by automatically picking up the incompatible mcp 2.0.0 release instead of the previously working 1.x series.

Documentation:
- Document the MCP dependency pin and CI breakage in the changelog.
- Add a roadmap item describing the required refactor to migrate to the mcp Python SDK v2 API.