### PR TITLE
fix(deps): revert pydantic-core to 2.46.4 to unblock Docker build

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -93,7 +93,7 @@ py-serializable==2.1.0
 pycparser==3.0
 pydantic==2.13.4
 pydantic-settings==2.14.2
-pydantic_core==2.47.0
+pydantic_core==2.46.4
 Pygments==2.20.0
 PyJWT==2.13.0
 pymdown-extensions==11.0.1

--- a/requirements-runtime-lock.txt
+++ b/requirements-runtime-lock.txt
@@ -43,7 +43,7 @@ more-itertools==11.1.0
 multidict==6.7.1
 propcache==0.5.2
 pycparser==3.0
-pydantic_core==2.47.0
+pydantic_core==2.46.4
 pydantic-settings==2.14.2
 pydantic==2.13.4
 Pygments==2.20.0


### PR DESCRIPTION
## Summary
- PR #755 bumped `pydantic-core` 2.46.4 → 2.47.0 standalone. The currently-pinned `pydantic==2.13.4` (latest stable release) requires `pydantic-core==2.46.4` exactly, so the lock files became self-conflicting.
- This has broken every "Build and Publish" Docker job on `main` since PR #755 merged (`ResolutionImpossible` on `pip install -r requirements-runtime-lock.txt`), and is why PR #760 (twine bump) appeared to fail — it's unrelated to twine, just the next PR to hit the pre-existing break.
- Reverts `pydantic-core` to the version `pydantic` actually requires until a `pydantic` release supporting `pydantic-core` 2.47.0 ships (none exists yet — checked available PyPI versions).

## Test plan
- [x] `pip install --dry-run -r requirements-runtime-lock.txt` resolves cleanly
- [x] Full test suite: 1336 passed, 8 skipped
- [ ] CI green on this PR (Build and Publish job in particular)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Revert the pydantic-core dependency version in lock files to restore compatibility with the currently pinned pydantic release and unblock Docker image builds.

Bug Fixes:
- Fix resolution conflicts in requirements lock files caused by an incompatible pydantic-core version bump.
- Restore successful Docker build and publish jobs that were failing during dependency installation.

Build:
- Update requirements lock files to pin pydantic-core back to the version required by the current pydantic release.