### PR TITLE
chore(deps): ignore mcp major-version bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,12 @@ updates:
       - "python"
     allow:
       - dependency-type: "all"
+    ignore:
+      # pyproject.toml pins mcp[cli]<2.0.0 — mcp 2.0.0 removed Server.list_resources
+      # and breaks the test suite (see PR #751). Re-enable once the codebase is
+      # migrated to the 2.x API.
+      - dependency-name: "mcp"
+        update-types: ["version-update:semver-major"]
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
## Summary
- `pyproject.toml` pins `mcp[cli]<2.0.0` because `mcp` 2.0.0 removed `Server.list_resources` and breaks the test suite (see PR #751, 2026-07-30).
- Dependabot was still opening lock-file-level major bumps anyway (PR #753) that reproduce the exact same regression (`AttributeError: 'Server' object has no attribute 'list_resources'`, 38 test-collection errors).
- Adds an `ignore` rule for `mcp` semver-major updates so Dependabot stops proposing it until the codebase is migrated to the 2.x API.

## Test plan
- [x] YAML validated (pre-commit hooks pass)
- [ ] Confirm no new `mcp` major-bump PR opens on the next Dependabot run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update Dependabot configuration to prevent lockfile PRs for mcp major-version bumps that currently break tests.