### PR TITLE
fix(security): bump cryptography to 50.0.0, document pip-vendor Trivy false positives

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -62,6 +62,21 @@ CVE-2025-8058
 # Risk: low — pip tool itself, not a project dependency; fix in pip>=26.1. Also ignored in pip-audit CI.
 CVE-2026-6357
 
+# setuptools 70.3.0 / msgpack 1.1.2: flagged by Trivy but NOT real installed packages.
+# Verified 2026-08-04 by building the image locally and inspecting the filesystem:
+# these version numbers come from pip's own internal `pip/_vendor/vendor.txt`, which
+# pins the versions pip vendors for its own bootstrapping (msgpack for pip's HTTP
+# cache, pkg_resources from setuptools for pip's legacy compatibility shims). Trivy's
+# python-pkg scanner parses vendor.txt as if it listed real installed distributions
+# (paths: None in `trivy image --format json` output, unlike the real setuptools
+# package, which correctly resolves to setuptools-83.0.0.dist-info — already patched).
+# Risk: low — these are dormant copies bundled inside pip itself, never imported by
+# application code, and pip does not run at container runtime (only during image
+# build). The project has no real dependency on msgpack at all.
+CVE-2025-47273
+CVE-2026-59890
+GHSA-6v7p-g79w-8964
+
 # --- Debian base image system package CVEs — no fix available in Debian Bookworm repos ---
 # These affect system tools not invoked by this application at runtime. The container
 # runs as a non-root user (uid 1000). All have no Debian backport at time of writing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   introduced; both already resolved in `requirements-lock.txt`.
 
 ### Security
+- **`cryptography` bumped 49.0.0 → 50.0.0** (CVE-2026-69247, HIGH): PKCS7 `EnvelopedData`
+  decryption exposed a Bleichenbacher oracle via distinguishable errors/timing. Not directly
+  reachable through this project's own use of `cryptography` (`vault.py` only uses
+  `AESGCM`/`InvalidTag`, not PKCS7), but fixed anyway since it's a direct runtime dependency.
+  Verified via the full test suite (including all Vault/crypto tests) plus a local Trivy rescan
+  of the built container image.
+- Two Trivy container-scan findings (`CVE-2025-47273`, `CVE-2026-59890` — setuptools; and
+  `GHSA-6v7p-g79w-8964` — msgpack) documented in `.trivyignore` as false positives: both version
+  numbers (`setuptools==70.3.0`, `msgpack==1.1.2`) come from `pip`'s own internal
+  `pip/_vendor/vendor.txt`, which pins versions `pip` vendors for its own bootstrapping (never
+  imported by this project, never on the runtime import path since `pip` doesn't run after image
+  build). Confirmed by building the image locally, inspecting the filesystem, and diffing
+  `trivy image --format json` package attribution against the real, already-patched
+  `setuptools==83.0.0` install.
 - Reconciled the two divergent Bandit configs: `.bandit` and `.github/workflows/security.yml`'s
   `bandit_skip` no longer skip B105 (hardcoded-password-string) — `pyproject.toml [tool.bandit]`
   never did. Kept active so key-handling code (`vault.py`) is guarded against accidentally

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -20,7 +20,7 @@ check-wheel-contents==0.6.3
 click==8.4.2
 colorama==0.4.6
 coverage==7.15.2
-cryptography==49.0.0
+cryptography==50.0.0
 cyclonedx-python-lib==11.11.0
 defusedxml==0.7.1
 distlib==0.4.3

--- a/requirements-runtime-lock.txt
+++ b/requirements-runtime-lock.txt
@@ -23,7 +23,7 @@ certifi==2026.7.22
 cffi==2.1.0
 charset-normalizer==3.4.9
 click==8.4.2
-cryptography==49.0.0
+cryptography==50.0.0
 frozenlist==1.8.0
 h11==0.16.0
 httpcore==1.0.9


### PR DESCRIPTION
## Summary
- Bumps `cryptography` 49.0.0 → 50.0.0 in `requirements-lock.txt` and `requirements-runtime-lock.txt`, fixing **CVE-2026-69247** (HIGH — PKCS7 `EnvelopedData` decryption Bleichenbacher oracle). Not directly reachable via this project's own usage (`vault.py` only uses `AESGCM`/`InvalidTag`, never PKCS7), but fixed since it's a direct runtime dependency.
- Adds three entries to `.trivyignore` for a confirmed false-positive class: Trivy's container scan flagged `setuptools==70.3.0` (CVE-2025-47273, CVE-2026-59890) and `msgpack==1.1.2` (GHSA-6v7p-g79w-8964) in the built image, but the real, already-patched `setuptools==83.0.0` is what's actually installed. Both flagged version numbers instead come from `pip`'s own internal `pip/_vendor/vendor.txt` — versions `pip` vendors for its own bootstrapping, never imported by this project's code, and not on the runtime import path since `pip` doesn't execute after image build.

## Verification
- Built the image locally (`docker build`) and inspected the filesystem directly to confirm the setuptools/msgpack root cause (only one real `setuptools-83.0.0.dist-info` exists; `msgpack` only exists as `pip/_vendor/msgpack`).
- Confirmed via `trivy image --format json` package attribution: the real `setuptools` package resolves to its actual `dist-info/METADATA` file (0 vulns); the flagged `setuptools 70.3.0`/`msgpack 1.1.2` entries show `paths: None` (i.e., not tied to a real installed-package file).
- Confirmed `cryptography 50.0.0`'s only dependency constraint (`cffi>=2.0.0`) is already satisfied by the locked `cffi==2.1.0` — no other lock-file changes needed.
- Full test suite: 1336 passed / 8 skipped (primary tree) + 112 passed / 9 skipped (legacy tree) — zero regressions.
- 58 vault/crypto-specific tests run explicitly and pass.
- `bandit -c pyproject.toml` and `mypy` clean on `vault.py`.
- Rebuilt the production image with the updated lock file and reran Trivy locally: `cryptography-50.0.0` and the setuptools/msgpack findings all show 0 vulnerabilities / suppressed.

## Test plan
- [x] `SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest tests/ -x -q --timeout=30` — 1336 passed, 8 skipped
- [x] `SIMPLENOTE_OFFLINE_MODE=true .venv/bin/pytest simplenote_mcp/tests/ -q --timeout=30 --no-cov` — 112 passed, 9 skipped
- [x] `.venv/bin/pytest tests/ -k vault` — 58 passed
- [x] `.venv/bin/bandit -c pyproject.toml -r simplenote_mcp/server/vault.py`
- [x] `.venv/bin/mypy simplenote_mcp/server/vault.py`
- [x] Local Docker build + `trivy image` rescan confirms all three findings resolved
- [x] Pre-commit hooks pass on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update security dependencies and document container scan false positives.

Enhancements:
- Upgrade cryptography runtime dependency to 50.0.0 to address a high-severity vulnerability while keeping tests and functionality intact.

CI:
- Document and suppress known Trivy false-positive findings for pip-vendored setuptools and msgpack in .trivyignore to keep container scans signal-focused.

Documentation:
- Add changelog entry describing the cryptography upgrade and the rationale for ignoring specific Trivy findings.