### PR TITLE
fix(deps): bump hono and nanoid to resolve Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2835,9 +2835,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3196,9 +3196,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Runs `npm audit fix` (non-force) on the npm eval-tooling devDependency tree (`package.json`/`package-lock.json`, used only by `npm run eval:*` — never shipped in the Docker image or PyPI package)
- Bumps `hono` 4.12.30 → 4.13.1, resolving 4 advisories: `memo()` SSR cross-user data disclosure, Connection-header leak in the Proxy Helper, Algorithmic Complexity DoS in Language Middleware, and ReDoS in CORS middleware
- Bumps `nanoid` 3.3.11 → 3.3.18, resolving 2 high-severity infinite-loop advisories
- No `mcp-evals` version change — both bumps are transitive and non-breaking

## Out of scope
Remaining Dependabot alerts (`@ai-sdk/*`, `@opentelemetry/*`, `jsondiffpatch`) only resolve via `mcp-evals@1.0.18`, a breaking downgrade from the current 2.0.1 (no newer 2.x release exists upstream yet that fixes them). Deliberately left as-is per prior triage — re-check `npm view mcp-evals versions` periodically.

## Test plan
- [x] `npm audit` confirms hono and nanoid advisories no longer present
- [x] `npm run validate:evals` passes (all 4 eval YAML files parse)
- [x] Full Python test suite: 1348 passed, 8 skipped (`make test-fast`)
- [x] Pre-commit hooks passed (trim-whitespace, check-json, mypy, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Run non-force npm audit fix on eval-tooling devDependency tree to refresh lockfile and resolve security alerts for hono and nanoid.