### PR TITLE
ci(docs): split docs.yml into thin caller + local reusable workflows [Phase 1]

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -11,7 +11,8 @@ CI/CD pipeline definitions. `unified-ci.yml` is the main pipeline (validate → 
 - `auto-fix.yml`, `auto-merge.yml`, `claude-dependabot-merge.yml`, `claude-status-check.yml` — Dependabot/PR automation.
 - `evaluation-quality-gate.yml`, `mcp-evaluations.yml` — mcp-evals suite runners; both gate on `ANTHROPIC_API_KEY` presence so Dependabot PRs (no repo secret access) skip gracefully instead of failing.
 - `release.yml` — manual `workflow_dispatch` version bump/release (patch/minor/major). `update-version.yml` — triggers on `v*.*.*` tag push, syncs version references post-release.
-- `docs.yml`, `monitoring-consolidated.yml`, `publish-pypi.yml` — docs build, consolidated monitoring checks, PyPI publish.
+- `docs.yml` — thin caller (docs build via `reusable-docs-build.yml`, Pages deploy via `reusable-docs-deploy.yml`, link check via `reusable-docs-link-check.yml`). `monitoring-consolidated.yml`, `publish-pypi.yml` — consolidated monitoring checks, PyPI publish.
+- `reusable-*.yml` — local `workflow_call` reusable workflows, each owned by and used only by the caller(s) listed against it above. Not standalone triggers; see the owning caller for `on:` semantics. Introduced 2026-08-12 as part of a phased thin-caller refactor (org-standard ≤80-line-per-file check) — the docdyhr org's usual pattern delegates to the separate `docdyhr/.github` repo (see `security.yml`/`claude-status-check.yml`/`claude-dependabot-merge.yml` below), but these use local composition instead by deliberate choice (no cross-repo versioning/tagging overhead for logic specific to this repo).
 
 ## Local Contracts
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,163 +15,26 @@ on:
       - "README.md"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
   build-docs:
-    name: Build Documentation
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-          cache: "pip"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e . || pip install -e .[test] || echo "Package installation failed, continuing with minimal setup"
-          pip install mkdocs mkdocs-material mkdocstrings[python] || echo "Some docs dependencies failed, continuing..."
-
-      - name: Verify installation
-        run: |
-          python -c "import simplenote_mcp; print('Package import successful')" || echo "Package import failed, continuing..."
-          mkdocs --version || echo "MkDocs not found, will create basic structure"
-        continue-on-error: true
-
-      - name: Verify docs structure
-        run: |
-          echo "📁 Checking documentation structure..."
-          if [ ! -d docs ]; then
-            echo "⚠️ docs directory missing, but mkdocs.yml exists - this is OK"
-          else
-            echo "✅ docs directory found"
-          fi
-
-          if [ ! -f mkdocs.yml ]; then
-            echo "❌ mkdocs.yml missing - this should not happen"
-            exit 1
-          else
-            echo "✅ mkdocs.yml found"
-          fi
-
-      - name: Verify API documentation
-        run: |
-          echo "📋 Checking API documentation..."
-          if [ ! -d docs/api ]; then
-            echo "⚠️ docs/api directory missing, but should exist from repo"
-          else
-            echo "✅ docs/api directory found"
-            ls -la docs/api/
-          fi
-
-      - name: Verify documentation files
-        run: |
-          echo "📄 Checking documentation files..."
-          for file in docs/index.md docs/installation.md docs/configuration.md docs/usage.md docs/contributing.md docs/changelog.md; do
-            if [ -f "$file" ]; then
-              echo "✅ $file found"
-            else
-              echo "⚠️ $file missing"
-            fi
-          done
-
-      - name: Build documentation
-        run: mkdocs build
-
-      - name: Upload documentation artifacts
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
-        with:
-          path: ./site
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-docs-build.yml
 
   deploy-docs:
-    timeout-minutes: 12
-    name: Deploy Documentation
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
     needs: build-docs
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Check GitHub Pages status
-        id: pages-check
-        run: |
-          echo "Checking if GitHub Pages is enabled..."
-          # This step will help diagnose the issue
-          echo "Repository: ${{ github.repository }}"
-          echo "Pages URL should be: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
-        continue-on-error: true
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
-        continue-on-error: true
-
-      - name: Handle deployment failure
-        if: failure()
-        run: |
-          echo "❌ GitHub Pages deployment failed"
-          echo "This is likely because GitHub Pages is not enabled for this repository"
-          echo "To enable GitHub Pages:"
-          echo "1. Go to: https://github.com/${{ github.repository }}/settings/pages"
-          echo "2. Under 'Source', select 'GitHub Actions'"
-          echo "3. Save the settings"
-          echo ""
-          echo "Documentation was built successfully and is available as an artifact"
-          exit 0  # Don't fail the entire workflow
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/reusable-docs-deploy.yml
 
   link-check:
-    timeout-minutes: 8
-    name: Check Documentation Links
-    runs-on: ubuntu-latest
     needs: build-docs
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Download documentation artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: github-pages
-          path: ./site
-
-      - name: Extract site
-        run: |
-          cd site
-          tar -xf artifact.tar
-
-      - name: Check links
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
-        with:
-          args: --verbose --no-progress --config .lycheerc.toml './site/**/*.html' --exclude-mail
-          fail: false  # Don't fail workflow on link issues, just report them
-          failIfEmpty: false  # Don't fail if no links found
-          output: lychee-report.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Upload link check report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: link-check-report
-          path: lychee-report.md
-          retention-days: 7
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-docs-link-check.yml

--- a/.github/workflows/reusable-docs-build.yml
+++ b/.github/workflows/reusable-docs-build.yml
@@ -1,0 +1,63 @@
+name: Reusable - Build Documentation
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to build docs with"
+        type: string
+        default: "3.12"
+
+jobs:
+  build-docs:
+    name: Build Documentation
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . || pip install -e ".[test]" || echo "Package installation failed, continuing with minimal setup"
+          pip install mkdocs mkdocs-material mkdocstrings[python] || echo "Some docs dependencies failed, continuing..."
+
+      - name: Verify installation
+        run: |
+          python -c "import simplenote_mcp; print('Package import successful')" || echo "Package import failed, continuing..."
+          mkdocs --version || echo "MkDocs not found, will create basic structure"
+        continue-on-error: true
+
+      - name: Verify docs structure and files
+        run: |
+          echo "📁 Checking documentation structure..."
+          if [ -d docs ]; then echo "✅ docs directory found"; else echo "⚠️ docs directory missing, but mkdocs.yml exists - this is OK"; fi
+          if [ -f mkdocs.yml ]; then echo "✅ mkdocs.yml found"; else echo "❌ mkdocs.yml missing - this should not happen"; exit 1; fi
+
+          echo "📋 Checking API documentation..."
+          if [ -d docs/api ]; then echo "✅ docs/api directory found"; ls -la docs/api/; else echo "⚠️ docs/api directory missing, but should exist from repo"; fi
+
+          echo "📄 Checking documentation files..."
+          for file in docs/index.md docs/installation.md docs/configuration.md docs/usage.md docs/contributing.md docs/changelog.md; do
+            if [ -f "$file" ]; then echo "✅ $file found"; else echo "⚠️ $file missing"; fi
+          done
+
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Upload documentation artifacts
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: ./site

--- a/.github/workflows/reusable-docs-deploy.yml
+++ b/.github/workflows/reusable-docs-deploy.yml
@@ -1,0 +1,43 @@
+name: Reusable - Deploy Documentation
+
+on:
+  workflow_call:
+
+jobs:
+  deploy-docs:
+    timeout-minutes: 12
+    name: Deploy Documentation
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Check GitHub Pages status
+        id: pages-check
+        run: |
+          echo "Checking if GitHub Pages is enabled..."
+          echo "Repository: ${{ github.repository }}"
+          echo "Pages URL should be: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+        continue-on-error: true
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        continue-on-error: true
+
+      - name: Handle deployment failure
+        if: failure()
+        run: |
+          echo "❌ GitHub Pages deployment failed"
+          echo "This is likely because GitHub Pages is not enabled for this repository"
+          echo "To enable GitHub Pages:"
+          echo "1. Go to: https://github.com/${{ github.repository }}/settings/pages"
+          echo "2. Under 'Source', select 'GitHub Actions'"
+          echo "3. Save the settings"
+          echo ""
+          echo "Documentation was built successfully and is available as an artifact"
+          exit 0  # Don't fail the entire workflow

--- a/.github/workflows/reusable-docs-link-check.yml
+++ b/.github/workflows/reusable-docs-link-check.yml
@@ -1,0 +1,46 @@
+name: Reusable - Documentation Link Check
+
+on:
+  workflow_call:
+
+jobs:
+  link-check:
+    timeout-minutes: 8
+    name: Check Documentation Links
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Download documentation artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: github-pages
+          path: ./site
+
+      - name: Extract site
+        run: |
+          cd site
+          tar -xf artifact.tar
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+        with:
+          args: --verbose --no-progress --config .lycheerc.toml './site/**/*.html' --exclude-mail
+          fail: false # Don't fail workflow on link issues, just report them
+          failIfEmpty: false # Don't fail if no links found
+          output: lychee-report.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Upload link check report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: link-check-report
+          path: lychee-report.md
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,6 @@ Thumbs.db
 **/.github/copilot/
 **/.copilot/
 **/.aider*
-CLAUDE.md
 
 # Documentation build output
 site/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [`AGENTS.md`](AGENTS.md) for commands, architecture, and repo-wide contracts, and its Child DOX Index for the per-folder `AGENTS.md` tree. Claude Code reads both files — durable content lives in `AGENTS.md` only, to avoid two diverging copies.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This allows Claude Desktop to interact with your Simplenote notes as a memory ba
 
 <!-- Project Info Badges -->
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://github.com/docdyhr/simplenote-mcp-server)
-[![Version](https://img.shields.io/badge/version-1.17.1-blue.svg)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.17.5-blue.svg)](./CHANGELOG.md)
 [![Test Coverage](https://img.shields.io/badge/coverage-77%25-brightgreen)](./htmlcov/index.html)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -37,7 +37,7 @@ This allows Claude Desktop to interact with your Simplenote notes as a memory ba
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Smithery](https://smithery.ai/badge/@docdyhr/simplenote-mcp-server)](https://smithery.ai/server/@docdyhr/simplenote-mcp-server)
 
-[![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/b215d030-b511-457d-8a6d-3e1e6ea3b541)
+[![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/docdyhr-simplenote-mcp-server)
 ---
 
 ## What's New
@@ -742,8 +742,6 @@ If you find this project helpful, please consider giving it a star on GitHub! Yo
 - 💪 **Motivate continued development** and maintenance
 - 📈 **Build community** around the Model Context Protocol ecosystem
 - 🛡️ **Validate trust** through community engagement
-
-[![GitHub stars](https://img.shields.io/github/stars/docdyhr/simplenote-mcp-server?style=social)](https://github.com/docdyhr/simplenote-mcp-server/stargazers)
 
 **[⭐ Star this repository](https://github.com/docdyhr/simplenote-mcp-server)** — it takes just one click and means a lot!
 


### PR DESCRIPTION
## Summary
Phase 1 of the CI thin-caller refactor (org-standard <=80-line-per-file audit check). Extracts docs.yml's 3 jobs into local `workflow_call` reusable workflows.

Draft PR opened purely to verify the reusable-workflow composition actually runs correctly on GitHub Actions (job dependency graph, permissions, artifact passing across jobs) before continuing to Phases 2-9. Also includes an earlier, independent commit (README badge fixes + CLAUDE.md git-tracking) from the same audit.

## Test plan
- [ ] `build-docs` job runs and succeeds
- [ ] `link-check` job runs after build-docs and succeeds (or reports non-blocking link issues as before)
- [ ] `deploy-docs` correctly skipped (PR context, not a push to main -- matches pre-refactor behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor the docs CI workflow into a thin caller that delegates to local reusable workflows for building, link checking, and deploying documentation.

New Features:
- Introduce reusable workflow_call-based jobs for documentation build, link checking, and GitHub Pages deployment.
- Add CLAUDE.md to document guidance and contracts for Claude Code when working with this repository.

Enhancements:
- Clarify CI workflow documentation in AGENTS.md to describe the new reusable docs workflows and their ownership.
- Update README badges to reflect the current released version and correct the MseeP verification link, while simplifying the GitHub stars call-to-action.

CI:
- Split docs.yml into a thin workflow that calls reusable-docs-build.yml, reusable-docs-link-check.yml, and reusable-docs-deploy.yml with appropriate job-level permissions.