### PR TITLE
docs: prepare CHANGELOG for v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-08-15
+
 ### Removed
 - **`memory_monitor.py` (dead code)**: `MemoryMonitor` was never imported or instantiated
   anywhere in the server, CLI, or test suite (0% coverage since introduction). Confirmed via
@@ -921,7 +923,8 @@ This release marks a significant milestone with **98% startup performance improv
 [1.10.1]: https://github.com/docdyhr/simplenote-mcp-server/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/docdyhr/simplenote-mcp-server/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/docdyhr/simplenote-mcp-server/compare/v1.8.1...v1.9.0
-[Unreleased]: https://github.com/docdyhr/simplenote-mcp-server/compare/v1.17.0...HEAD
+[Unreleased]: https://github.com/docdyhr/simplenote-mcp-server/compare/v1.18.0...HEAD
+[1.18.0]: https://github.com/docdyhr/simplenote-mcp-server/compare/v1.17.5...v1.18.0
 [1.17.0]: https://github.com/docdyhr/simplenote-mcp-server/compare/v1.16.1...v1.17.0
 [1.16.1]: https://github.com/docdyhr/simplenote-mcp-server/compare/v1.16.0...v1.16.1
 [1.16.0]: https://github.com/docdyhr/simplenote-mcp-server/compare/v1.15.0...v1.16.0


### PR DESCRIPTION
## Summary
- Renames the `[Unreleased]` section to `[1.18.0] - 2026-08-15`, adding a fresh empty `[Unreleased]` above it
- Updates the comparison-links footer (`[Unreleased]` now diffs from `v1.18.0`, adds a `[1.18.0]` compare link from `v1.17.5`)
- Prepares the repo for the `release.yml` workflow_dispatch (`bump_type=minor`) to cut v1.18.0

## Test plan
- [x] Local fast test suite green (1348 passed, 8 skipped)
- [x] Pre-commit hooks passed on the commit (mypy, EOF/whitespace checks)
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare CHANGELOG for the 1.18.0 release by adding the 1.18.0 section and updating comparison links for Unreleased and 1.18.0.

Documentation:
- Add a new 1.18.0 section to the CHANGELOG with release date 2026-08-15 and move existing changes from Unreleased into it.
- Update CHANGELOG comparison links so Unreleased now compares from v1.18.0 and a new 1.18.0 link compares v1.17.5 to v1.18.0.