### PR TITLE
ci(release): authenticate release.yml's version-bump push as an admin PAT

### DIFF
--- a/.github/workflows/reusable-release-prepare.yml
+++ b/.github/workflows/reusable-release-prepare.yml
@@ -46,6 +46,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          # main requires 3 status checks on every push (branch protection added
+          # 2026-08-11); GITHUB_TOKEN authenticates as github-actions[bot], which
+          # is not an admin and so cannot push a fresh commit straight to main
+          # (GH006). RELEASE_ADMIN_TOKEN is a classic PAT from an admin account;
+          # enforce_admins is false, so an admin-authenticated push bypasses the
+          # required-checks block. Falls back to GITHUB_TOKEN if the secret is
+          # ever removed (fails the same way this did before the secret existed).
+          token: ${{ secrets.RELEASE_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
## Summary
- `main` branch protection (added 2026-08-11) requires 3 status checks (`Dependency Review`, `test / Test`, `security / Security`) on every push
- `release.yml`'s `prepare-release` job pushes the version-bump commit straight to `main` using `GITHUB_TOKEN`, which authenticates as `github-actions[bot]` — not a repo admin — so the push was rejected: `GH006: Protected branch update failed`, `3 of 3 required status checks are expected`
- Discovered live while attempting to cut v1.18.0 (see the failed run: https://github.com/docdyhr/simplenote-mcp-server/actions/runs/31867178333)
- `enforce_admins` is `false` on this repo's branch protection, so an admin-authenticated push bypasses the required-checks block — this points the checkout step's `token:` at a new `RELEASE_ADMIN_TOKEN` repo secret (a classic PAT from an admin account), falling back to `GITHUB_TOKEN` if that secret is ever unset

## Test plan
- [x] `actionlint` passes on the modified workflow file
- [x] Local pre-commit hooks passed on the commit
- [ ] CI checks pass on this PR
- [ ] Manual: re-trigger `release.yml` with `bump_type=minor` after this merges + `RELEASE_ADMIN_TOKEN` is set, confirm the `Push changes` step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update reusable release prepare workflow to use a RELEASE_ADMIN_TOKEN secret for checkout authentication, falling back to GITHUB_TOKEN when unavailable.