### PR TITLE
docs: update version references to v1.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This allows Claude Desktop to interact with your Simplenote notes as a memory ba
 
 <!-- Project Info Badges -->
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://github.com/docdyhr/simplenote-mcp-server)
-[![Version](https://img.shields.io/badge/version-1.17.5-blue.svg)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.18.0-blue.svg)](./CHANGELOG.md)
 [![Test Coverage](https://img.shields.io/badge/coverage-77%25-brightgreen)](./htmlcov/index.html)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -217,7 +217,7 @@ docker-compose up -d
 Available tags:
 
 - `latest` - Latest stable release
-- `v1.17.5` - Specific version
+- `v1.18.0` - Specific version
 - `main` - Latest development build
 
 ### Production Deployment

--- a/helm/simplenote-mcp-server/values.yaml
+++ b/helm/simplenote-mcp-server/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
   repository: docdyhr/simplenote-mcp-server
   pullPolicy: IfNotPresent
-  tag: "v1.17.5"
+  tag: "v1.18.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary
- Updates README.md's version badge and Docker tag documentation (1.17.5 → 1.18.0)
- Updates helm/simplenote-mcp-server/values.yaml's default image tag (v1.17.5 → v1.18.0)
- These aren't covered by release.yml's automated version bump (only pyproject.toml, simplenote_mcp/__init__.py, VERSION, Chart.yaml, and setup.py are), matching the pattern of the prior #790 follow-up

## Test plan
- [x] Local pre-commit hooks passed on the commit
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation and Helm configuration to reference release v1.18.0 instead of v1.17.5.

Deployment:
- Update Helm chart default container image tag to v1.18.0.

Documentation:
- Refresh README version badge and Docker tag examples to use v1.18.0.