### PR TITLE
chore(dependabot): ignore standalone pydantic-core bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,12 @@ updates:
       - "python"
     allow:
       - dependency-type: "all"
+    ignore:
+      # pydantic_core is pinned exactly by pydantic (pydantic==2.13.4 requires
+      # pydantic_core==2.46.4), so a standalone bump is unsatisfiable and fails
+      # the Docker build with ResolutionImpossible — see closed PR #811.
+      # It moves only when pydantic itself bumps.
+      - dependency-name: "pydantic-core"
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
## Summary

Stops Dependabot from re-opening an unmergeable `pydantic-core` PR every week.

`pydantic` pins `pydantic_core` to an exact version — `pydantic==2.13.4` requires `pydantic_core==2.46.4` — so a standalone bump of `pydantic-core` is unsatisfiable by construction. #811 attempted `2.46.4 → 2.48.0` and failed the Docker build:

```
ERROR: Cannot install -r requirements-runtime-lock.txt (line 47) and pydantic_core==2.48.0
because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

That PR was closed. Without this ignore, Dependabot has no way to know about the constraint and will keep re-opening the same PR on its Sunday run.

A bare `dependency-name` with no `versions`/`update-types` suppresses all updates for the package, which is the intent here: `pydantic_core` should move only when `pydantic` itself bumps, which the grouped `pydantic` update already handles.

## Validation

Validated against the official SchemaStore `dependabot-2.0` schema (not just `yaml.safe_load`, which passes on schema-invalid configs):

- Pre-change (`HEAD`): 1 schema error
- Post-change: the same 1 schema error, none added

That remaining error is **pre-existing and unrelated to this PR**: `updates[0].groups.security-dependencies.update-types` is `["security"]`, but for *groups* the schema permits only `major`/`minor`/`patch` (a security-only group is spelled `applies-to: security-updates`). Left as-is here to keep this change scoped — worth a separate look, since it means that group likely never behaved as written.

Note that pre-commit's file hooks skip `.github/`, so this file gets no pre-commit coverage; the schema check above was the actual validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Prevent standalone Dependabot updates for pydantic-core so it is updated only alongside compatible pydantic releases.