### PR TITLE
chore(dependabot): fix invalid update-types in security-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,13 +33,15 @@ updates:
           - "mcp*"
           - "simplenote*"
       security-dependencies:
+        # A group's `update-types` accepts only major/minor/patch; "security"
+        # was invalid and silently prevented this group from applying.
+        # Security-only grouping is expressed via `applies-to`.
+        applies-to: "security-updates"
         dependency-type: "production"
         patterns:
           - "starlette*"
           - "urllib3*"
           - "requests*"
-        update-types:
-          - "security"
       development-dependencies:
         dependency-type: "development"
         patterns:


### PR DESCRIPTION
## Summary

The `security-dependencies` group declared:

```yaml
      security-dependencies:
        dependency-type: "production"
        patterns: ["starlette*", "urllib3*", "requests*"]
        update-types:
          - "security"      # <-- invalid
```

A group's `update-types` accepts **only** `major` / `minor` / `patch`. `security` is not a valid value there — security-only grouping is expressed with `applies-to: security-updates`. Because the value was invalid, the group never applied as written, so security updates for starlette/urllib3/requests were not actually being grouped.

Confirmed directly against the resolved schema node (`definitions.update.properties.groups.additionalProperties`):

- `applies-to` → enum `["version-updates", "security-updates"]`
- `update-types` → items enum `["major", "minor", "patch"]`

## Change

Replaces the invalid `update-types` with `applies-to: "security-updates"`, keeping the same `dependency-type` and `patterns`.

## Validation

Against the official SchemaStore `dependabot-2.0` schema:

| | errors |
|---|---|
| before (this branch's parent) | 1 |
| after | **0** |

The whole config validates cleanly for the first time. The `pydantic-core` ignore added in #817 is unaffected and still present.

This was found while validating #817 and reported there as pre-existing and out of scope; this PR is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure Dependabot to apply the production security dependency group to security updates.

Bug Fixes:
- Fix the Dependabot security dependency group so security updates for production dependencies are grouped correctly.

Chores:
- Correct the Dependabot configuration by replacing the invalid security update type with the supported security-update scope.