### PR TITLE
fix(docker): bust BuildKit layer cache weekly for apt-get upgrade

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -82,6 +82,10 @@ jobs:
             type=sha,prefix={{date 'YYYYMMDD'}}-
             type=schedule,pattern={{date 'YYYYMMDD'}}
 
+      - name: Compute weekly cache-bust date
+        id: cache_date
+        run: echo "date=$(date -u +%Y-W%V)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -92,6 +96,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CACHE_DATE=${{ steps.cache_date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ ARG PYTHON_VERSION
 WORKDIR /app
 
 # Install build dependencies (upgrade first to pick up latest security patches)
+# CACHE_DATE busts the BuildKit layer cache weekly (passed as %Y-W%V from CI)
+# so apt-get upgrade always hits a live mirror at least once a week instead of
+# silently reusing a stale cached layer indefinitely (cache-to: mode=max has
+# no built-in expiry).
+ARG CACHE_DATE
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     gcc \
     build-essential \
@@ -54,6 +59,8 @@ RUN groupadd -g 1000 mcp && useradd -u 1000 -g mcp -m -d /home/mcp mcp
 WORKDIR /app
 
 # Apply security updates and install minimal runtime dependencies
+# CACHE_DATE busts the BuildKit layer cache weekly, see builder stage above.
+ARG CACHE_DATE
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- The `apt-get update && apt-get upgrade` layer in both Dockerfile stages was being cached indefinitely by `cache-to: type=gha,mode=max`, so upstream security patches never made it into the published image until the GHA cache happened to be evicted.
- Confirmed today: manually clearing the BuildKit GHA cache and rebuilding resolved 6 unpatched `util-linux`/`libblkid` CVEs (including one HIGH severity) that had been sitting open in code scanning even though the Dockerfile always intended to upgrade on every build.
- Adds a `CACHE_DATE` build-arg (ISO year-week, e.g. `2026-W33`) computed in the workflow and passed into both Dockerfile stages right before their `apt-get` layer, so that layer's cache key rotates at least weekly instead of persisting forever. Everything else keeps its existing cache behavior — only the apt layer (and what follows it in each stage) is affected.

## Test plan
- [x] `actionlint .github/workflows/reusable-docker-build.yml` passes
- [x] Pre-commit hooks pass (mypy, whitespace/EOF checks)
- [ ] CI (`Unified CI/CD Pipeline`) build_and_publish job builds and pushes successfully with the new build-arg
- [ ] Manually verify next week's build picks up a new `CACHE_DATE` value and re-runs the apt layer instead of reusing this week's cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refresh cached Docker image security-update layers weekly so published images receive current APT security patches.

Bug Fixes:
- Ensure Docker image builds refresh APT package indexes and apply upstream security upgrades at least weekly instead of indefinitely reusing the BuildKit cache.

CI:
- Compute and pass a weekly cache-busting build argument to both Docker build stages.