### PR TITLE
fix(ci): use native GitHub auto-merge for Dependabot PRs

### DIFF
--- a/.github/workflows/reusable-dependabot-auto-merge.yml
+++ b/.github/workflows/reusable-dependabot-auto-merge.yml
@@ -31,7 +31,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Wait for CI checks to complete
+      - name: Enable auto-merge for Dependabot PRs
         if: >
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
            steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
@@ -42,31 +42,8 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Waiting for CI checks to complete..."
-          for _ in {1..30}; do
-            PENDING=$(gh pr checks "$PR_URL" --json state --jq '[.[] | select(.state == "PENDING")] | length' 2>/dev/null || echo "1")
-            if [ "$PENDING" = "0" ]; then echo "All checks completed"; break; fi
-            echo "Checks still pending ($PENDING remaining), waiting 10s..."
-            sleep 10
-          done
-
-      - name: Merge Dependabot PRs
-        if: >
-          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-           steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
-          !contains(steps.metadata.outputs.dependency-names, 'cryptography') &&
-          !contains(steps.metadata.outputs.dependency-names, 'requests') &&
-          !contains(steps.metadata.outputs.dependency-names, 'urllib3') &&
-          !contains(steps.metadata.outputs.dependency-names, 'aiohttp')
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          FAILED=$(gh pr checks "$PR_URL" --json state --jq '[.[] | select(.state == "FAILURE")] | length' 2>/dev/null || echo "0")
-          if [ "$FAILED" != "0" ]; then
-            echo "Some checks failed, skipping merge"
-            exit 0
-          fi
-          gh pr merge --squash --delete-branch "$PR_URL" || { echo "Direct merge failed, PR may need manual review"; exit 0; }
-          echo "Successfully merged PR"
+        # Native GitHub auto-merge lets GitHub itself wait for required status
+        # checks to register and pass, instead of a manual poll-then-merge
+        # race that can fire before checks exist yet and fail against branch
+        # protection ("the base branch policy prohibits the merge").
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
## Root Cause

`reusable-dependabot-auto-merge.yml`'s merge step polled `gh pr checks` for
`state == "PENDING"` and then immediately ran `gh pr merge --squash`. This
races against branch protection: required checks (`Dependency Review`,
`test / Test`, `security / Security`) can take a moment to even be *created*
after a push, so the poll can read "0 pending" before they exist, then the
merge attempt fails with:

```
X Pull request #825 is not mergeable: the base branch policy prohibits the merge.
```

That failure was swallowed by `|| { echo ...; exit 0; }`, so the job reported
success while the PR sat open, approved, with no further signal anything had
gone wrong.

Found during a `/triage` run today: PRs #819, #822, #825, #827 were all
semver-minor, CI-green, and stuck exactly this way — confirmed via each PR's
`dependabot-auto-merge` job log (all hit the same `not mergeable` line at the
merge step). All four have since been merged manually.

## Fix

Replace the poll-then-merge steps with `gh pr merge --auto --squash
--delete-branch`, GitHub's native auto-merge. This is the same pattern this
repo already uses in `reusable-auto-merge-pr.yml`'s fallback path — GitHub
itself watches required checks and completes the merge once they pass, so
there's no timing race and no need to swallow a failure.

## Verification

- `actionlint .github/workflows/reusable-dependabot-auto-merge.yml` — clean
- `pre-commit` (mypy) — passed
- Repo has `allow_auto_merge: true`, confirmed via `gh api /repos/.../` — required for `--auto` to work

---
*Generated by Claude Code, following up on today's `/triage` run*

## Summary by Sourcery

Use GitHub-native auto-merge for eligible Dependabot pull requests instead of polling checks and attempting an immediate merge.

Bug Fixes:
- Prevent Dependabot pull requests from remaining open when merge attempts race with branch-protection checks.

Enhancements:
- Use GitHub-native auto-merge to wait for required checks before completing eligible Dependabot merges.