### PR TITLE
fix(deps): resolve httpcore2/httpx2 lock-file conflict breaking Docker build

### DIFF
--- a/requirements-runtime-lock.txt
+++ b/requirements-runtime-lock.txt
@@ -27,8 +27,8 @@ cryptography==50.0.0
 frozenlist==1.8.0
 h11==0.16.0
 httpcore2==2.12.0
-httpx2==2.10.0
-idna==3.18
+httpx2==2.12.0
+idna==3.19
 jaraco.classes==3.4.0
 jaraco.context==6.1.2
 jaraco.functools==4.6.0
@@ -46,7 +46,7 @@ propcache==0.5.2
 pycparser==3.0
 pydantic==2.13.4
 pydantic_core==2.46.4
-Pygments==2.20.0
+Pygments==2.21.0
 PyJWT==2.13.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.3


### PR DESCRIPTION
## Root Cause
dependency

`requirements-runtime-lock.txt` pinned `httpcore2==2.12.0` (bumped by #840) alongside `httpx2==2.10.0`, which requires `httpcore2==2.10.0` exactly. This broke `pip install -r requirements-runtime-lock.txt` inside the Docker build (`build_and_publish` job) with `ResolutionImpossible`:

```
ERROR: Cannot install -r requirements-runtime-lock.txt (line 30) and httpcore2==2.12.0 because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested httpcore2==2.12.0
    httpx2 2.10.0 depends on httpcore2==2.10.0; sys_platform != "emscripten"
```

Reproduced on both the #838 and #840 PR CI runs (both post-merge), so every build has been failing since, not just a one-off.

## Fix
Regenerated `requirements-runtime-lock.txt` via its own documented process (clean venv → `pip install .` → `pip freeze`) instead of hand-editing pins, so pip's resolver picks a mutually-compatible pair rather than a guessed one. Result: `httpx2` moves `2.10.0` → `2.12.0` (a release that supports `httpcore2==2.12.0`). Also picked up two incidental transitive bumps that had drifted since the lock file was last regenerated (`idna` 3.18→3.19, `Pygments` 2.20.0→2.21.0).

## Verification
- `pip install -r requirements-runtime-lock.txt && pip install --no-deps .` succeeds cleanly in a fresh venv (reproduces the exact Docker build install steps).
- Full test suite: `tests/` 1348 passed / 8 skipped; `simplenote_mcp/tests/` 112 passed / 9 skipped. No failures.
- Pre-commit hooks (mypy, whitespace/EOF checks) passed on the commit.

---
*Filed via /triage.*

## Summary by Sourcery

Restore successful Docker builds by updating the runtime dependency lock file to compatible package versions.

Bug Fixes:
- Resolve the runtime dependency lock conflict between httpx2 and httpcore2 that was breaking Docker builds.

Build:
- Regenerate the runtime lock file with mutually compatible dependency versions, including updated httpx2, idna, and Pygments pins.

Tests:
- Verify the dependency installation flow and full test suites pass with the regenerated lock file.