### PR TITLE
fix(deps): override jsondiffpatch to ^0.7.2 to resolve XSS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@dmsnell/diff-match-patch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz",
+      "integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.2",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
@@ -1756,13 +1763,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -2608,13 +2608,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/digest-fetch": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
@@ -3362,34 +3355,19 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.6.tgz",
+      "integrity": "sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
+        "@dmsnell/diff-match-patch": "^1.1.0"
       },
       "bin": {
         "jsondiffpatch": "bin/jsondiffpatch.js"
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/jsondiffpatch/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "tsx": "^4.23.12"
   },
   "overrides": {
-    "undici": "^6.28.0"
+    "undici": "^6.28.0",
+    "jsondiffpatch": "^0.7.2"
   }
 }


### PR DESCRIPTION
Resolves Dependabot alert [#29](https://github.com/docdyhr/simplenote-mcp-server/security/dependabot/29) (GHSA-33vc-wfww-vjfv, **medium**) — jsondiffpatch XSS via `HtmlFormatter::nodeBegin` in `< 0.7.2`.

## Why an override rather than a bump

`jsondiffpatch` is a transitive **dev** dependency reached only via:

```
mcp-evals@2.0.1 -> ai@4.3.19 -> jsondiffpatch@0.6.0
```

Bumping the parent cannot fix it. `mcp-evals@2.0.1` is the latest published release and pins `ai: ^4.3.9`, while the matching `ai` advisory is first patched in `5.0.52`. No `mcp-evals` release can reach it — upstream has to ship a new major first. That is why Dependabot has sat on these two alerts since 2026-07-13 without opening a PR: it has no valid resolution to offer.

Adding the override alongside the existing `undici` one takes `jsondiffpatch` to `0.7.6`.

## Semver caveat — deliberate

`ai@4.3.19` pins `jsondiffpatch` at **exactly** `0.6.0`, so this override intentionally violates that pin. It is safe in this repo: `jsondiffpatch` is referenced only from `ai/rsc/*` (React Server Components streaming UI), which an MCP eval harness never loads. Confirmed by grep — no reference anywhere else in the `ai` package.

## Verification

- `npm audit` — `jsondiffpatch` now **CLEAN**
- `ai` and `jsondiffpatch` both still import cleanly (ESM)
- `npm run validate:evals` — all 4 eval YAML files pass
- Python suite — **1348 passed, 8 skipped**, coverage 81.44% (gate 75%)

## Not covered here

Alert [#30](https://github.com/docdyhr/simplenote-mcp-server/security/dependabot/30) (`ai`, **low** — filetype whitelist bypass on upload) stays open. Same upstream block, and the affected upload path is likewise unreachable from the eval harness. Suggest dismissing it as *not affected* until `mcp-evals` moves to `ai@5.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve the jsondiffpatch security advisory by enforcing a patched transitive dependency version.

Bug Fixes:
- Override the transitive jsondiffpatch dependency to a patched 0.7.x release, resolving its known XSS vulnerability.

Build:
- Update the lockfile to reflect the dependency override.